### PR TITLE
feat(whatsapp): add mention_only gating for group messages

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -3486,6 +3486,8 @@ fn collect_configured_channels(
                                 wa.pair_code.clone(),
                                 wa.allowed_numbers.clone(),
                                 wa.allowed_groups.clone(),
+                                wa.mention_only,
+                                wa.mention_name.clone(),
                             )
                             .with_transcription(config.transcription.clone())
                             .with_tts(config.tts.clone()),

--- a/src/channels/whatsapp_web.rs
+++ b/src/channels/whatsapp_web.rs
@@ -60,6 +60,10 @@ pub struct WhatsAppWebChannel {
     allowed_numbers: Vec<String>,
     /// Allowed group chats (JID, "*", or "dm")
     allowed_groups: Vec<String>,
+    /// When true, only respond to group messages that mention the bot by name
+    mention_only: bool,
+    /// Bot name for text-based mention detection (case-insensitive)
+    mention_name: Option<String>,
     /// Bot handle for shutdown
     bot_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
     /// Client handle for sending messages and typing indicators
@@ -96,6 +100,8 @@ impl WhatsAppWebChannel {
         pair_code: Option<String>,
         allowed_numbers: Vec<String>,
         allowed_groups: Vec<String>,
+        mention_only: bool,
+        mention_name: Option<String>,
     ) -> Self {
         Self {
             session_path,
@@ -103,6 +109,8 @@ impl WhatsAppWebChannel {
             pair_code,
             allowed_numbers,
             allowed_groups,
+            mention_only,
+            mention_name,
             bot_handle: Arc::new(Mutex::new(None)),
             client: Arc::new(Mutex::new(None)),
             tx: Arc::new(Mutex::new(None)),
@@ -129,6 +137,12 @@ impl WhatsAppWebChannel {
             self.tts_config = Some(config);
         }
         self
+    }
+
+    /// Check if message text contains the bot's mention name (case-insensitive).
+    #[cfg(feature = "whatsapp-web")]
+    fn contains_mention(text: &str, mention_name: &str) -> bool {
+        text.to_lowercase().contains(&mention_name.to_lowercase())
     }
 
     /// Check if a phone number is allowed (E.164 format: +1234567890)
@@ -652,6 +666,8 @@ impl Channel for WhatsAppWebChannel {
             let tx_clone = tx.clone();
             let allowed_numbers = self.allowed_numbers.clone();
             let allowed_groups = self.allowed_groups.clone();
+            let mention_only = self.mention_only;
+            let mention_name = self.mention_name.clone();
             let logout_tx_clone = logout_tx.clone();
             let retry_count_clone = retry_count.clone();
             let session_revoked_clone = session_revoked.clone();
@@ -668,6 +684,8 @@ impl Channel for WhatsAppWebChannel {
                     let tx_inner = tx_clone.clone();
                     let allowed_numbers = allowed_numbers.clone();
                     let allowed_groups = allowed_groups.clone();
+                    let mention_only = mention_only;
+                    let mention_name = mention_name.clone();
                     let logout_tx = logout_tx_clone.clone();
                     let retry_count = retry_count_clone.clone();
                     let session_revoked = session_revoked_clone.clone();
@@ -716,6 +734,22 @@ impl Channel for WhatsAppWebChannel {
                                         chat, normalized
                                     );
                                     return;
+                                }
+
+                                // Mention-only filter: skip group messages that don't mention the bot
+                                let is_group = chat.ends_with("@g.us");
+                                if mention_only && is_group {
+                                    let text = msg.text_content().unwrap_or("");
+                                    let mentioned = mention_name.as_deref().map_or(false, |name| {
+                                        Self::contains_mention(text, name)
+                                    });
+                                    if !mentioned {
+                                        tracing::debug!(
+                                            "WhatsApp Web: mention_only=true, no mention found in group message from {}, skipping",
+                                            normalized
+                                        );
+                                        return;
+                                    }
                                 }
 
                                 // Attempt voice note transcription (ptt = push-to-talk = voice note)
@@ -1020,6 +1054,9 @@ impl WhatsAppWebChannel {
         _pair_phone: Option<String>,
         _pair_code: Option<String>,
         _allowed_numbers: Vec<String>,
+        _allowed_groups: Vec<String>,
+        _mention_only: bool,
+        _mention_name: Option<String>,
     ) -> Self {
         Self { _private: () }
     }
@@ -1087,6 +1124,8 @@ mod tests {
             None,
             vec!["+1234567890".into()],
             vec![],
+            false,
+            None,
         )
     }
 
@@ -1109,7 +1148,7 @@ mod tests {
     #[cfg(feature = "whatsapp-web")]
     fn whatsapp_web_number_allowed_wildcard() {
         let ch =
-            WhatsAppWebChannel::new("/tmp/test.db".into(), None, None, vec!["*".into()], vec![]);
+            WhatsAppWebChannel::new("/tmp/test.db".into(), None, None, vec!["*".into()], vec![], false, None);
         assert!(ch.is_number_allowed("+1234567890"));
         assert!(ch.is_number_allowed("+9999999999"));
     }
@@ -1117,7 +1156,7 @@ mod tests {
     #[test]
     #[cfg(feature = "whatsapp-web")]
     fn whatsapp_web_number_denied_empty() {
-        let ch = WhatsAppWebChannel::new("/tmp/test.db".into(), None, None, vec![], vec![]);
+        let ch = WhatsAppWebChannel::new("/tmp/test.db".into(), None, None, vec![], vec![], false, None);
         // Empty allowlist means "deny all" (matches channel-wide allowlist policy).
         assert!(!ch.is_number_allowed("+1234567890"));
     }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -4767,6 +4767,14 @@ pub struct WhatsAppConfig {
     /// Allowed group chats (JID or "*" for all, "dm" for direct messages only)
     #[serde(default)]
     pub allowed_groups: Vec<String>,
+    /// When true, only respond to messages that mention the bot's name in groups.
+    /// Direct messages are always processed.
+    #[serde(default)]
+    pub mention_only: bool,
+    /// Bot name used for text-based mention detection in groups (e.g. "claw").
+    /// Case-insensitive. Only used when mention_only = true.
+    #[serde(default)]
+    pub mention_name: Option<String>,
 }
 
 impl ChannelConfig for WhatsAppConfig {
@@ -9296,6 +9304,8 @@ channel_id = "C123"
             pair_code: None,
             allowed_numbers: vec!["+1234567890".into(), "+9876543210".into()],
             allowed_groups: vec![],
+            mention_only: false,
+            mention_name: None,
         };
         let json = serde_json::to_string(&wc).unwrap();
         let parsed: WhatsAppConfig = serde_json::from_str(&json).unwrap();
@@ -9317,6 +9327,8 @@ channel_id = "C123"
             pair_code: None,
             allowed_numbers: vec!["+1".into()],
             allowed_groups: vec![],
+            mention_only: false,
+            mention_name: None,
         };
         let toml_str = toml::to_string(&wc).unwrap();
         let parsed: WhatsAppConfig = toml::from_str(&toml_str).unwrap();
@@ -9343,6 +9355,8 @@ channel_id = "C123"
             pair_code: None,
             allowed_numbers: vec!["*".into()],
             allowed_groups: vec![],
+            mention_only: false,
+            mention_name: None,
         };
         let toml_str = toml::to_string(&wc).unwrap();
         let parsed: WhatsAppConfig = toml::from_str(&toml_str).unwrap();
@@ -9361,6 +9375,8 @@ channel_id = "C123"
             pair_code: None,
             allowed_numbers: vec!["+1".into()],
             allowed_groups: vec![],
+            mention_only: false,
+            mention_name: None,
         };
         assert!(wc.is_ambiguous_config());
         assert_eq!(wc.backend_type(), "cloud");
@@ -9378,6 +9394,8 @@ channel_id = "C123"
             pair_code: None,
             allowed_numbers: vec![],
             allowed_groups: vec![],
+            mention_only: false,
+            mention_name: None,
         };
         assert!(!wc.is_ambiguous_config());
         assert_eq!(wc.backend_type(), "web");
@@ -9405,6 +9423,8 @@ channel_id = "C123"
                 pair_code: None,
                 allowed_numbers: vec!["+1".into()],
                 allowed_groups: vec![],
+                mention_only: false,
+                mention_name: None,
             }),
             linq: None,
             wati: None,

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -4260,6 +4260,8 @@ fn setup_channels() -> Result<ChannelsConfig> {
                             .then(|| pair_code.trim().to_string()),
                         allowed_numbers,
                         allowed_groups: vec![],
+                        mention_only: false,
+                        mention_name: None,
                     });
 
                     println!(
@@ -4362,6 +4364,8 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     pair_code: None,
                     allowed_numbers,
                     allowed_groups: vec![],
+                    mention_only: false,
+                    mention_name: None,
                 });
             }
             ChannelMenuChoice::Linq => {


### PR DESCRIPTION
## Summary

- Adds `mention_only` and `mention_name` config fields to `WhatsAppConfig`, matching the pattern used by Telegram/Discord/Slack channels
- When `mention_only = true`, only group messages containing the bot's `mention_name` are processed; DMs are always allowed
- Wires through factory, updates stub and onboard wizard defaults

## Config example

```toml
[channels.whatsapp]
mention_only = true
mention_name = "claw"
```

## Test plan

- [x] `cargo check --features whatsapp-web` — compiles clean
- [x] `cargo test --features whatsapp-web -- whatsapp` — 14 tests pass
- [x] No new clippy warnings (all pre-existing)
- [ ] Manual: deploy to remote, verify group messages without mention are skipped
- [ ] Manual: verify DMs still work regardless of mention_only setting