### PR TITLE
feat(memory): add metadata field for WhatsApp group JID persistence

### DIFF
--- a/src/agent/memory_loader.rs
+++ b/src/agent/memory_loader.rs
@@ -114,6 +114,7 @@ mod tests {
                 timestamp: "now".into(),
                 session_id: None,
                 score: None,
+                metadata: None,
             }])
         }
 
@@ -220,6 +221,7 @@ mod tests {
                     timestamp: "now".into(),
                     session_id: None,
                     score: Some(0.95),
+                    metadata: None,
                 },
                 MemoryEntry {
                     id: "2".into(),
@@ -229,6 +231,7 @@ mod tests {
                     timestamp: "now".into(),
                     session_id: None,
                     score: Some(0.9),
+                    metadata: None,
                 },
             ]),
         };

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -2004,13 +2004,19 @@ async fn process_channel_message(
         && !memory::should_skip_autosave_content(&msg.content)
     {
         let autosave_key = conversation_memory_key(&msg);
+        let metadata = if msg.reply_target.ends_with("@g.us") {
+            Some(format!(r#"{{"group_jid":"{}"}}"#, msg.reply_target))
+        } else {
+            None
+        };
         let _ = ctx
             .memory
-            .store(
+            .store_with_metadata(
                 &autosave_key,
                 &msg.content,
                 crate::memory::MemoryCategory::Conversation,
                 Some(&history_key),
+                metadata.as_deref(),
             )
             .await;
     }
@@ -6163,6 +6169,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 timestamp: "2026-02-20T00:00:00Z".to_string(),
                 session_id: None,
                 score: Some(0.9),
+                metadata: None,
             }])
         }
 

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1332,16 +1332,22 @@ async fn handle_whatsapp_message(
         );
         let session_id = sender_session_id("whatsapp", msg);
 
-        // Auto-save to memory
+        // Auto-save to memory (include group JID metadata for WhatsApp groups)
         if state.auto_save && !memory::should_skip_autosave_content(&msg.content) {
             let key = whatsapp_memory_key(msg);
+            let metadata = if msg.reply_target.ends_with("@g.us") {
+                Some(format!(r#"{{"group_jid":"{}"}}"#, msg.reply_target))
+            } else {
+                None
+            };
             let _ = state
                 .mem
-                .store(
+                .store_with_metadata(
                     &key,
                     &msg.content,
                     MemoryCategory::Conversation,
                     Some(&session_id),
+                    metadata.as_deref(),
                 )
                 .await;
         }

--- a/src/memory/lucid.rs
+++ b/src/memory/lucid.rs
@@ -226,6 +226,7 @@ impl LucidMemory {
                 timestamp: now.clone(),
                 session_id: None,
                 score: Some((1.0 - rank as f64 * 0.05).max(0.1)),
+                metadata: None,
             });
         }
 
@@ -315,6 +316,21 @@ impl Memory for LucidMemory {
     ) -> anyhow::Result<()> {
         self.local
             .store(key, content, category.clone(), session_id)
+            .await?;
+        self.sync_to_lucid_async(key, content, &category).await;
+        Ok(())
+    }
+
+    async fn store_with_metadata(
+        &self,
+        key: &str,
+        content: &str,
+        category: MemoryCategory,
+        session_id: Option<&str>,
+        metadata: Option<&str>,
+    ) -> anyhow::Result<()> {
+        self.local
+            .store_with_metadata(key, content, category.clone(), session_id, metadata)
             .await?;
         self.sync_to_lucid_async(key, content, &category).await;
         Ok(())

--- a/src/memory/markdown.rs
+++ b/src/memory/markdown.rs
@@ -91,6 +91,7 @@ impl MarkdownMemory {
                     timestamp: filename.to_string(),
                     session_id: None,
                     score: None,
+                    metadata: None,
                 }
             })
             .collect()

--- a/src/memory/postgres.rs
+++ b/src/memory/postgres.rs
@@ -134,6 +134,7 @@ impl PostgresMemory {
             timestamp: timestamp.to_rfc3339(),
             session_id: row.get(5),
             score: row.try_get(6).ok(),
+            metadata: None,
         })
     }
 }

--- a/src/memory/qdrant.rs
+++ b/src/memory/qdrant.rs
@@ -363,6 +363,7 @@ impl Memory for QdrantMemory {
                     timestamp: payload.timestamp,
                     session_id: payload.session_id,
                     score: Some(point.score),
+                    metadata: None,
                 })
             })
             .collect();
@@ -419,6 +420,7 @@ impl Memory for QdrantMemory {
                 timestamp: payload.timestamp,
                 session_id: payload.session_id,
                 score: None,
+                metadata: None,
             })
         });
 
@@ -496,6 +498,7 @@ impl Memory for QdrantMemory {
                     timestamp: payload.timestamp,
                     session_id: payload.session_id,
                     score: None,
+                    metadata: None,
                 })
             })
             .collect();

--- a/src/memory/sqlite.rs
+++ b/src/memory/sqlite.rs
@@ -172,15 +172,19 @@ impl SqliteMemory {
         )?;
 
         // Migration: add session_id column if not present (safe to run repeatedly)
-        let has_session_id: bool = conn
+        let schema_sql: String = conn
             .prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='memories'")?
-            .query_row([], |row| row.get::<_, String>(0))?
-            .contains("session_id");
-        if !has_session_id {
+            .query_row([], |row| row.get::<_, String>(0))?;
+        if !schema_sql.contains("session_id") {
             conn.execute_batch(
                 "ALTER TABLE memories ADD COLUMN session_id TEXT;
                  CREATE INDEX IF NOT EXISTS idx_memories_session ON memories(session_id);",
             )?;
+        }
+
+        // Migration: add metadata column if not present (safe to run repeatedly)
+        if !schema_sql.contains("metadata") {
+            conn.execute_batch("ALTER TABLE memories ADD COLUMN metadata TEXT;")?;
         }
 
         Ok(())
@@ -476,6 +480,48 @@ impl Memory for SqliteMemory {
         .await?
     }
 
+    async fn store_with_metadata(
+        &self,
+        key: &str,
+        content: &str,
+        category: MemoryCategory,
+        session_id: Option<&str>,
+        metadata: Option<&str>,
+    ) -> anyhow::Result<()> {
+        let embedding_bytes = self
+            .get_or_compute_embedding(content)
+            .await?
+            .map(|emb| vector::vec_to_bytes(&emb));
+
+        let conn = self.conn.clone();
+        let key = key.to_string();
+        let content = content.to_string();
+        let sid = session_id.map(String::from);
+        let meta = metadata.map(String::from);
+
+        tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+            let conn = conn.lock();
+            let now = Local::now().to_rfc3339();
+            let cat = Self::category_to_str(&category);
+            let id = Uuid::new_v4().to_string();
+
+            conn.execute(
+                "INSERT INTO memories (id, key, content, category, embedding, created_at, updated_at, session_id, metadata)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+                 ON CONFLICT(key) DO UPDATE SET
+                    content = excluded.content,
+                    category = excluded.category,
+                    embedding = excluded.embedding,
+                    updated_at = excluded.updated_at,
+                    session_id = excluded.session_id,
+                    metadata = excluded.metadata",
+                params![id, key, content, cat, embedding_bytes, now, now, sid, meta],
+            )?;
+            Ok(())
+        })
+        .await?
+    }
+
     async fn recall(
         &self,
         query: &str,
@@ -539,7 +585,7 @@ impl Memory for SqliteMemory {
                     .collect::<Vec<_>>()
                     .join(", ");
                 let sql = format!(
-                    "SELECT id, key, content, category, created_at, session_id \
+                    "SELECT id, key, content, category, created_at, session_id, metadata \
                      FROM memories WHERE id IN ({placeholders})"
                 );
                 let mut stmt = conn.prepare(&sql)?;
@@ -557,17 +603,18 @@ impl Memory for SqliteMemory {
                         row.get::<_, String>(3)?,
                         row.get::<_, String>(4)?,
                         row.get::<_, Option<String>>(5)?,
+                        row.get::<_, Option<String>>(6)?,
                     ))
                 })?;
 
                 let mut entry_map = std::collections::HashMap::new();
                 for row in rows {
-                    let (id, key, content, cat, ts, sid) = row?;
-                    entry_map.insert(id, (key, content, cat, ts, sid));
+                    let (id, key, content, cat, ts, sid, meta) = row?;
+                    entry_map.insert(id, (key, content, cat, ts, sid, meta));
                 }
 
                 for scored in &merged {
-                    if let Some((key, content, cat, ts, sid)) = entry_map.remove(&scored.id) {
+                    if let Some((key, content, cat, ts, sid, meta)) = entry_map.remove(&scored.id) {
                         let entry = MemoryEntry {
                             id: scored.id.clone(),
                             key,
@@ -576,6 +623,7 @@ impl Memory for SqliteMemory {
                             timestamp: ts,
                             session_id: sid,
                             score: Some(f64::from(scored.final_score)),
+                            metadata: meta.and_then(|m| serde_json::from_str(&m).ok()),
                         };
                         if let Some(filter_sid) = session_ref {
                             if entry.session_id.as_deref() != Some(filter_sid) {
@@ -607,7 +655,7 @@ impl Memory for SqliteMemory {
                         .collect();
                     let where_clause = conditions.join(" OR ");
                     let sql = format!(
-                        "SELECT id, key, content, category, created_at, session_id FROM memories
+                        "SELECT id, key, content, category, created_at, session_id, metadata FROM memories
                          WHERE {where_clause}
                          ORDER BY updated_at DESC
                          LIMIT ?{}",
@@ -624,6 +672,7 @@ impl Memory for SqliteMemory {
                     let params_ref: Vec<&dyn rusqlite::types::ToSql> =
                         param_values.iter().map(AsRef::as_ref).collect();
                     let rows = stmt.query_map(params_ref.as_slice(), |row| {
+                        let meta: Option<String> = row.get(6)?;
                         Ok(MemoryEntry {
                             id: row.get(0)?,
                             key: row.get(1)?,
@@ -632,6 +681,7 @@ impl Memory for SqliteMemory {
                             timestamp: row.get(4)?,
                             session_id: row.get(5)?,
                             score: Some(1.0),
+                            metadata: meta.and_then(|m| serde_json::from_str(&m).ok()),
                         })
                     })?;
                     for row in rows {
@@ -659,10 +709,11 @@ impl Memory for SqliteMemory {
         tokio::task::spawn_blocking(move || -> anyhow::Result<Option<MemoryEntry>> {
             let conn = conn.lock();
             let mut stmt = conn.prepare(
-                "SELECT id, key, content, category, created_at, session_id FROM memories WHERE key = ?1",
+                "SELECT id, key, content, category, created_at, session_id, metadata FROM memories WHERE key = ?1",
             )?;
 
             let mut rows = stmt.query_map(params![key], |row| {
+                let meta: Option<String> = row.get(6)?;
                 Ok(MemoryEntry {
                     id: row.get(0)?,
                     key: row.get(1)?,
@@ -671,6 +722,7 @@ impl Memory for SqliteMemory {
                     timestamp: row.get(4)?,
                     session_id: row.get(5)?,
                     score: None,
+                    metadata: meta.and_then(|m| serde_json::from_str(&m).ok()),
                 })
             })?;
 
@@ -699,6 +751,7 @@ impl Memory for SqliteMemory {
             let mut results = Vec::new();
 
             let row_mapper = |row: &rusqlite::Row| -> rusqlite::Result<MemoryEntry> {
+                let meta: Option<String> = row.get(6)?;
                 Ok(MemoryEntry {
                     id: row.get(0)?,
                     key: row.get(1)?,
@@ -707,13 +760,14 @@ impl Memory for SqliteMemory {
                     timestamp: row.get(4)?,
                     session_id: row.get(5)?,
                     score: None,
+                    metadata: meta.and_then(|m| serde_json::from_str(&m).ok()),
                 })
             };
 
             if let Some(ref cat) = category {
                 let cat_str = Self::category_to_str(cat);
                 let mut stmt = conn.prepare(
-                    "SELECT id, key, content, category, created_at, session_id FROM memories
+                    "SELECT id, key, content, category, created_at, session_id, metadata FROM memories
                      WHERE category = ?1 ORDER BY updated_at DESC LIMIT ?2",
                 )?;
                 let rows = stmt.query_map(params![cat_str, DEFAULT_LIST_LIMIT], row_mapper)?;
@@ -728,7 +782,7 @@ impl Memory for SqliteMemory {
                 }
             } else {
                 let mut stmt = conn.prepare(
-                    "SELECT id, key, content, category, created_at, session_id FROM memories
+                    "SELECT id, key, content, category, created_at, session_id, metadata FROM memories
                      ORDER BY updated_at DESC LIMIT ?1",
                 )?;
                 let rows = stmt.query_map(params![DEFAULT_LIST_LIMIT], row_mapper)?;

--- a/src/memory/traits.rs
+++ b/src/memory/traits.rs
@@ -11,6 +11,9 @@ pub struct MemoryEntry {
     pub timestamp: String,
     pub session_id: Option<String>,
     pub score: Option<f64>,
+    /// Arbitrary JSON metadata (e.g. group_jid for WhatsApp group messages).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
 }
 
 impl std::fmt::Debug for MemoryEntry {
@@ -109,6 +112,21 @@ pub trait Memory: Send + Sync {
 
     /// Health check
     async fn health_check(&self) -> bool;
+
+    /// Store a memory entry with optional JSON metadata.
+    ///
+    /// Default implementation delegates to [`store`] and discards metadata.
+    /// Override in backends that support metadata persistence (e.g. SQLite).
+    async fn store_with_metadata(
+        &self,
+        key: &str,
+        content: &str,
+        category: MemoryCategory,
+        session_id: Option<&str>,
+        _metadata: Option<&str>,
+    ) -> anyhow::Result<()> {
+        self.store(key, content, category, session_id).await
+    }
 }
 
 #[cfg(test)]
@@ -156,6 +174,7 @@ mod tests {
             timestamp: "2026-02-16T00:00:00Z".into(),
             session_id: Some("session-abc".into()),
             score: Some(0.98),
+            metadata: None,
         };
 
         let json = serde_json::to_string(&entry).unwrap();


### PR DESCRIPTION
## Summary

- Adds `metadata: Option<serde_json::Value>` to `MemoryEntry` struct
- Adds `store_with_metadata()` to `Memory` trait with default impl (ignores metadata)
- SQLite: idempotent `ALTER TABLE` migration for `metadata TEXT` column + override
- Lucid backend: delegates `store_with_metadata` to inner SQLite
- Daemon + gateway autosave: attaches `{"group_jid":"...@g.us"}` when `reply_target` is a WhatsApp group
- Non-SQLite backends gracefully ignore metadata via default trait impl

Closes #5

## Query example

```sql
SELECT key, content, metadata FROM memories
WHERE json_extract(metadata, '$.group_jid') = '120363407513744860@g.us'
ORDER BY created_at DESC LIMIT 10;
```

## Test plan

- [x] `cargo check --features whatsapp-web` — compiles clean
- [x] `cargo test --features whatsapp-web` — 4126 tests pass, 0 failures
- [x] No new clippy warnings
- [ ] Manual: deploy, send WhatsApp group message, verify `metadata` column populated in brain.db
- [ ] Manual: verify DM messages have `metadata = NULL`
- [ ] Manual: verify existing data unaffected (migration is additive-only)