### PR TITLE
fix(cron): restore WhatsApp Web live channel delivery

### DIFF
--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -14,7 +14,7 @@ use crate::cron::{
     sync_declarative_jobs, update_job,
 };
 use crate::security::SecurityPolicy;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use futures_util::{StreamExt, stream};
 use std::process::Stdio;
@@ -440,18 +440,23 @@ fn resolve_matrix_delivery_room(configured_room_id: &str, target: &str) -> Strin
 
 async fn deliver_if_configured(config: &Config, job: &CronJob, output: &str) -> Result<()> {
     let delivery: &DeliveryConfig = &job.delivery;
-    if !delivery.mode.eq_ignore_ascii_case("announce") {
+
+    // Determine if delivery is requested:
+    // - Explicit "announce" mode (legacy format)
+    // - Channel set with no mode / empty mode (simplified format)
+    // - "none" mode → skip delivery
+    let has_channel = delivery.channel.as_deref().is_some_and(|c| !c.is_empty());
+    let mode = delivery.mode.trim().to_ascii_lowercase();
+    if mode == "none" || (!has_channel && mode != "announce") {
         return Ok(());
     }
 
     let channel = delivery
         .channel
         .as_deref()
-        .ok_or_else(|| anyhow::anyhow!("delivery.channel is required for announce mode"))?;
-    let target = delivery
-        .to
-        .as_deref()
-        .ok_or_else(|| anyhow::anyhow!("delivery.to is required for announce mode"))?;
+        .ok_or_else(|| anyhow::anyhow!("delivery.channel is required for delivery"))?;
+    // `to` is optional for live-channel delivery (channel knows its target)
+    let target = delivery.to.as_deref().unwrap_or("");
 
     deliver_announcement(config, channel, target, output).await
 }
@@ -497,6 +502,19 @@ pub(crate) async fn deliver_announcement(
     // Scan for credential leaks before delivering cron job output to channel.
     let safe_output = scan_and_redact_output(channel, target, output);
 
+    // Try the live channel registry first -- this reuses the daemon's
+    // connected channel instances, which is required for stateful
+    // channels like WhatsApp Web that need an active browser session.
+    if let Some(live_ch) = crate::channels::get_live_channel(channel) {
+        live_ch
+            .send(&SendMessage::new(safe_output.as_str(), target))
+            .await
+            .with_context(|| format!("live channel '{channel}' delivery failed"))?;
+        return Ok(());
+    }
+
+    // Fall back to constructing a new channel instance (works for
+    // stateless HTTP-based channels like Telegram, Discord, Slack).
     match channel.to_ascii_lowercase().as_str() {
         "telegram" => {
             let tg = config


### PR DESCRIPTION
## Summary

WhatsApp Web cron delivery has been silently failing since 2026-04-02. The scheduler generated briefs correctly but delivered nothing. The Papís morning brief has not reached the family group since 2026-04-04.

This cherry-picks upstream commit [`7758532a`](https://github.com/zeroclaw-labs/zeroclaw/commit/7758532a) (Giulio V, PR zeroclaw-labs/zeroclaw#4548) to restore correct delivery behavior.

## Root cause

`deliver_announcement()` in `src/cron/scheduler.rs` was constructing a fresh `WhatsAppWebChannel` from config values on every delivery attempt. The fresh instance had no paired session and no websocket — its `.send()` always failed. Inbound messages worked because the receive loop uses the separate live channel registered by `start_channels()`.

This regression entered our fork during the upstream sync merge [`5f2bf8636`](https://github.com/Micra-io/zeroclaw/commit/5f2bf8636) on 2026-04-02. The fix already exists upstream as `7758532a` (merged 2026-03-28) but was collateral damage in a mass revert [`c3ff6353`](https://github.com/zeroclaw-labs/zeroclaw/commit/c3ff6353) ("roll back 153 commits merged today") 39 minutes after it landed.

The failures were invisible because `RUST_LOG=zeroclaw::providers::anthropic=debug` on the deployed daemon silences every other module's warnings, including `persist_job_result`'s `Cron delivery failed: {e}` line.

## Solution

Add a live-channel short-circuit at the top of `deliver_announcement()`. When a channel with the requested name is registered in the live registry (populated by `start_channels()`), use it directly. Fall back to disposable construction only for stateless HTTP channels (Telegram, Discord, Slack).

```rust
if let Some(live_ch) = crate::channels::get_live_channel(channel) {
    live_ch
        .send(&SendMessage::new(safe_output.as_str(), target))
        .await
        .with_context(|| format!("live channel '{channel}' delivery failed"))?;
    return Ok(());
}
```

Our fork already has `register_live_channels()` and `get_live_channel()` defined in `src/channels/mod.rs` (from an earlier merge), and `start_channels()` already calls `register_live_channels(channels_by_name.as_ref())`. Only the scheduler's short-circuit was missing. The cherry-pick auto-merge initially duplicated the helpers — this PR contains the deduped result (single source of truth for the registry, scheduler.rs changes only).

## Changes

- `src/cron/scheduler.rs`: add live-channel short-circuit at the top of `deliver_announcement()` (+25/-7)

## Testing

### Build
```bash
cargo build --release --features whatsapp-web,observability-otel
```
Finished in 5m 31s. No warnings, no errors.

### End-to-end verification on remote daemon
1. Deployed the patched binary via `cat | ssh > ~/.cargo/bin/zeroclaw`, codesigned, restarted the daemon via `zeroclaw service restart`
2. Temporarily pointed `papi_morning_brief` delivery at my personal WhatsApp number and rescheduled 3 minutes out
3. Watched `cron_runs` table in `~/.zeroclaw/workspace/cron/jobs.db`

**Result:** run 1292 completed with `status=ok`, `duration_ms=17951`, full brief rendered with weather + all four news sections, and message landed on my personal WhatsApp. Before the fix, the same scheduler path was marking runs `status=error` with no visible log line because the delivery `warn!` was silenced.

### Restored production values after test
- `expression = 30 8 * * *` (08:30 Europe/Madrid, daily)
- `delivery.to = 120363407668337348@g.us` (Papís group)
- Next scheduled run: 2026-04-09 08:30 Madrid

## Known pre-existing issues (not addressed here)

1. **`cron_run` tool never calls delivery.** `src/tools/cron_run.rs` calls `execute_job_now()` directly, skipping `persist_job_result()`. Every manual test via this tool today reported `status=ok` while silently bypassing WhatsApp. Worth filing as a separate bug.
2. **`RUST_LOG` filter on the daemon.** The launchd plist sets `RUST_LOG=zeroclaw::providers::anthropic=debug`, which silences scheduler warnings. Broader default would make failures like this one diagnosable immediately.

## AI Assistance

**Session ID:** `19440ea3-57a0-4ce7-b068-32ff39533c53`

## Related

- Cherry-picks zeroclaw-labs/zeroclaw#4548 (Giulio V)
- Original author: Giulio V `<vannini.gv@gmail.com>`, preserved via commit authorship