### PR TITLE
fix(memory): prevent cron scheduler recursive memory explosion (#33)

### DIFF
--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -289,6 +289,7 @@ async fn run_agent_job(
             Ok(entries) if !entries.is_empty() => {
                 let ctx: String = entries
                     .iter()
+                    .filter(|e| !crate::memory::is_assistant_autosave_key(&e.key))
                     .filter(|e| !crate::memory::should_skip_autosave_content(&e.content))
                     .map(|e| format!("- {}: {}", e.key, e.content))
                     .collect::<Vec<_>>()

--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -289,10 +289,15 @@ async fn run_agent_job(
             Ok(entries) if !entries.is_empty() => {
                 let ctx: String = entries
                     .iter()
+                    .filter(|e| !crate::memory::should_skip_autosave_content(&e.content))
                     .map(|e| format!("- {}: {}", e.key, e.content))
                     .collect::<Vec<_>>()
                     .join("\n");
-                format!("[Memory context]\n{ctx}\n\n")
+                if ctx.is_empty() {
+                    String::new()
+                } else {
+                    format!("[Memory context]\n{ctx}\n[/Memory context]\n\n")
+                }
             }
             _ => String::new(),
         },

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -112,6 +112,7 @@ pub fn should_skip_autosave_content(content: &str) -> bool {
     let lowered = normalized.to_ascii_lowercase();
     lowered.starts_with("[cron:")
         || lowered.starts_with("[heartbeat task")
+        || lowered.starts_with("[memory context]")
         || lowered.starts_with("[distilled_")
         || lowered.contains("distilled_index_sig:")
 }

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -448,6 +448,17 @@ mod tests {
         assert!(!should_skip_autosave_content(
             "User prefers concise answers."
         ));
+
+        // Memory context prefix must be filtered (prevents recursive cron explosion — issue #33)
+        assert!(should_skip_autosave_content(
+            "[Memory context]\n- key: value\n\n[cron:42 patrol] check status"
+        ));
+        assert!(should_skip_autosave_content(
+            "[memory context]\n- key: value\n\n[cron:42 patrol] check status"
+        ));
+        assert!(should_skip_autosave_content(
+            "[MEMORY CONTEXT]\n- key: value"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Prevents cron scheduler memory recall from recursively inflating brain.db by adding a missing autosave guard and hardening the recall path.

**Story:** STORY-007 | **Issue:** Closes #33

### Problem

The cron scheduler recalls memories and prefixes them as `[Memory context]` to agent prompts. The agent loop autosaves the full message — including the prefix — back to brain.db. The autosave filter (`should_skip_autosave_content`) handled `[cron:`, `[heartbeat task`, and `[distilled_` but missed `[memory context]`. Each cron run doubled the stored content, producing 2.9 GB of corrupt data and killing all cron jobs with 413 errors.

This is an upstream bug (zeroclaw-labs/zeroclaw#4916) inherited via sync. Upstream has unmerged fix branches; this PR applies the same fix.

### Solution

1. Added `[memory context]` guard to `should_skip_autosave_content()` — breaks the feedback loop
2. Hardened scheduler recall: filters entries through both `is_assistant_autosave_key` and `should_skip_autosave_content` before re-injecting, adds `[/Memory context]` closing tag
3. Production cleanup: brain.db compacted from 448 MB to 3.0 MB

## Changes

- `src/memory/mod.rs` — one-line guard + 3 test assertions covering case-insensitive variants
- `src/cron/scheduler.rs` — filter recalled entries through autosave guards, add closing tag, skip empty results

## Testing

- Unit test: `autosave_content_filter_drops_cron_and_distilled_noise` extended with `[Memory context]`, `[memory context]`, `[MEMORY CONTEXT]` assertions
- Spec compliance review: passed
- Code quality review: approved (reviewer caught missing `is_assistant_autosave_key` guard — fixed)
- Production: binary deployed, brain.db compacted 448 MB → 3.0 MB, daemon healthy

## AI Assistance

**Session ID:** `316f3cf8-5acc-4284-b39d-1d4cd758ae37`