### PR TITLE
fix(cron): filter tool_result entries from scheduler memory recall

### DIFF
--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -291,6 +291,7 @@ async fn run_agent_job(
                     .iter()
                     .filter(|e| !crate::memory::is_assistant_autosave_key(&e.key))
                     .filter(|e| !crate::memory::should_skip_autosave_content(&e.content))
+                    .filter(|e| !e.content.contains("<tool_result"))
                     .map(|e| format!("- {}: {}", e.key, e.content))
                     .collect::<Vec<_>>()
                     .join("\n");


### PR DESCRIPTION
## Summary

- Adds missing `<tool_result>` content filter to scheduler memory recall chain, matching the guard already present in `build_context` (`loop_.rs:370`) and `should_skip_memory_context_entry` (`channels/mod.rs:1533`)
- Without this filter, stale tool output from previous heartbeat ticks can leak into cron prompts as orphaned XML, causing hallucinated tool responses

## Context

Found during post-merge review of #34 (ce:review finding #1, 3-reviewer agreement: correctness, testing, maintainability). PR #34 ported 2 of 3 recall filters from `build_context` but missed this one.

**Upstream:** zeroclaw-labs/zeroclaw#4916

## Changes

- `src/cron/scheduler.rs` — one-line filter addition: `.filter(|e| !e.content.contains("<tool_result"))`

## Test plan

- [x] `cargo check --features whatsapp-web` passes
- [ ] Deploy to remote and verify cron jobs exclude tool_result entries from `[Memory context]` block