### PR TITLE
feat(openrouter): add prompt caching support (#STORY-008)

### DIFF
--- a/src/agent/context_analyzer.rs
+++ b/src/agent/context_analyzer.rs
@@ -71,6 +71,7 @@ mod tests {
         ChatMessage {
             role: role.to_string(),
             content: content.to_string(),
+            stable_prefix: None,
         }
     }
 

--- a/src/agent/context_compressor.rs
+++ b/src/agent/context_compressor.rs
@@ -586,6 +586,7 @@ mod tests {
         ChatMessage {
             role: role.to_string(),
             content: content.to_string(),
+            stable_prefix: None,
         }
     }
 

--- a/src/multimodal.rs
+++ b/src/multimodal.rs
@@ -623,6 +623,7 @@ mod tests {
             ChatMessage {
                 role: "assistant".to_string(),
                 content: "[IMAGE:/tmp/assistant.png]\nAssistant generated".to_string(),
+                stable_prefix: None,
             },
             ChatMessage::user("[IMAGE:/tmp/user1.png]\nFirst".to_string()),
             ChatMessage::user("[IMAGE:/tmp/user2.png]\nSecond".to_string()),
@@ -680,11 +681,13 @@ mod tests {
             ChatMessage {
                 role: "assistant".to_string(),
                 content: "I see a photo.".to_string(),
+                stable_prefix: None,
             },
             ChatMessage::user("[IMAGE:/tmp/2.png]\nWhat about this?".to_string()),
             ChatMessage {
                 role: "assistant".to_string(),
                 content: "That's a chart.".to_string(),
+                stable_prefix: None,
             },
             ChatMessage::user("[IMAGE:/tmp/3.png]\nAnd this one".to_string()),
         ];

--- a/src/providers/anthropic.rs
+++ b/src/providers/anthropic.rs
@@ -1582,10 +1582,12 @@ mod tests {
             ChatMessage {
                 role: "system".to_string(),
                 content: "System prompt".to_string(),
+                stable_prefix: None,
             },
             ChatMessage {
                 role: "user".to_string(),
                 content: "Hello".to_string(),
+                stable_prefix: None,
             },
         ];
         // Only 1 non-system message — should not cache
@@ -1597,12 +1599,14 @@ mod tests {
         let mut messages = vec![ChatMessage {
             role: "system".to_string(),
             content: "System prompt".to_string(),
+            stable_prefix: None,
         }];
         // Add 3 non-system messages
         for i in 0..3 {
             messages.push(ChatMessage {
                 role: if i % 2 == 0 { "user" } else { "assistant" }.to_string(),
                 content: format!("Message {i}"),
+                stable_prefix: None,
             });
         }
         assert!(AnthropicProvider::should_cache_conversation(&messages));
@@ -1613,6 +1617,7 @@ mod tests {
         let messages = vec![ChatMessage {
             role: "user".to_string(),
             content: "Hello".to_string(),
+            stable_prefix: None,
         }];
         // Exactly 1 non-system message — should not cache
         assert!(!AnthropicProvider::should_cache_conversation(&messages));
@@ -1622,10 +1627,12 @@ mod tests {
             ChatMessage {
                 role: "user".to_string(),
                 content: "Hello".to_string(),
+                stable_prefix: None,
             },
             ChatMessage {
                 role: "assistant".to_string(),
                 content: "Hi".to_string(),
+                stable_prefix: None,
             },
         ];
         assert!(AnthropicProvider::should_cache_conversation(&messages));
@@ -1744,6 +1751,7 @@ mod tests {
         let messages = vec![ChatMessage {
             role: "system".to_string(),
             content: "Short system prompt".to_string(),
+            stable_prefix: None,
         }];
 
         let (system_prompt, _) = AnthropicProvider::convert_messages(&messages);
@@ -1769,6 +1777,7 @@ mod tests {
         let messages = vec![ChatMessage {
             role: "system".to_string(),
             content: large_content.clone(),
+            stable_prefix: None,
         }];
 
         let (system_prompt, _) = AnthropicProvider::convert_messages(&messages);
@@ -1828,18 +1837,22 @@ mod tests {
             ChatMessage {
                 role: "system".to_string(),
                 content: "You are helpful.".to_string(),
+                stable_prefix: None,
             },
             ChatMessage {
                 role: "user".to_string(),
                 content: "gen a 2 sum in golang".to_string(),
+                stable_prefix: None,
             },
             ChatMessage {
                 role: "assistant".to_string(),
                 content: "```go\nfunc twoSum(nums []int) {}\n```".to_string(),
+                stable_prefix: None,
             },
             ChatMessage {
                 role: "user".to_string(),
                 content: "what's meaning of make here?".to_string(),
+                stable_prefix: None,
             },
         ];
 
@@ -2026,6 +2039,7 @@ mod tests {
             role: "user".to_string(),
             content: "Check this image: [IMAGE:data:image/jpeg;base64,/9j/4AAQ] What do you see?"
                 .to_string(),
+            stable_prefix: None,
         }];
 
         let (_, native_msgs) = AnthropicProvider::convert_messages(&messages);
@@ -2064,6 +2078,7 @@ mod tests {
         let messages = vec![ChatMessage {
             role: "user".to_string(),
             content: "[IMAGE:data:image/png;base64,iVBORw0KGgo]".to_string(),
+            stable_prefix: None,
         }];
 
         let (_, native_msgs) = AnthropicProvider::convert_messages(&messages);
@@ -2093,6 +2108,7 @@ mod tests {
         let messages = vec![ChatMessage {
             role: "user".to_string(),
             content: "Hello, how are you?".to_string(),
+            stable_prefix: None,
         }];
 
         let (_, native_msgs) = AnthropicProvider::convert_messages(&messages);
@@ -2137,10 +2153,12 @@ mod tests {
             ChatMessage {
                 role: "system".to_string(),
                 content: "You are helpful.".to_string(),
+                stable_prefix: None,
             },
             ChatMessage {
                 role: "user".to_string(),
                 content: "Do two things.".to_string(),
+                stable_prefix: None,
             },
             ChatMessage {
                 role: "assistant".to_string(),
@@ -2152,6 +2170,7 @@ mod tests {
                     ]
                 })
                 .to_string(),
+                stable_prefix: None,
             },
             ChatMessage {
                 role: "tool".to_string(),
@@ -2160,6 +2179,7 @@ mod tests {
                     "content": "file1.txt\nfile2.txt"
                 })
                 .to_string(),
+                stable_prefix: None,
             },
             ChatMessage {
                 role: "tool".to_string(),
@@ -2168,6 +2188,7 @@ mod tests {
                     "content": "/home/user"
                 })
                 .to_string(),
+                stable_prefix: None,
             },
         ];
 
@@ -2202,6 +2223,7 @@ mod tests {
             ChatMessage {
                 role: "user".to_string(),
                 content: "Hello".to_string(),
+                stable_prefix: None,
             },
             ChatMessage {
                 role: "assistant".to_string(),
@@ -2212,6 +2234,7 @@ mod tests {
                     ]
                 })
                 .to_string(),
+                stable_prefix: None,
             },
             ChatMessage {
                 role: "tool".to_string(),
@@ -2220,10 +2243,12 @@ mod tests {
                     "content": "hi"
                 })
                 .to_string(),
+                stable_prefix: None,
             },
             ChatMessage {
                 role: "user".to_string(),
                 content: "Thanks!".to_string(),
+                stable_prefix: None,
             },
         ];
 

--- a/src/providers/bedrock.rs
+++ b/src/providers/bedrock.rs
@@ -1534,6 +1534,7 @@ mod tests {
             messages.push(ChatMessage {
                 role: if i % 2 == 0 { "user" } else { "assistant" }.to_string(),
                 content: format!("Message {i}"),
+                stable_prefix: None,
             });
         }
         assert!(BedrockProvider::should_cache_conversation(&messages));
@@ -1735,6 +1736,7 @@ mod tests {
             ChatMessage {
                 role: "tool".to_string(),
                 content: "not valid json".to_string(),
+                stable_prefix: None,
             },
         ];
         let (_, msgs) = BedrockProvider::convert_messages(&messages);
@@ -1757,6 +1759,7 @@ mod tests {
             ChatMessage {
                 role: "tool".to_string(),
                 content: "raw output with no json".to_string(),
+                stable_prefix: None,
             },
         ];
         let (_, msgs) = BedrockProvider::convert_messages(&messages);

--- a/src/providers/compatible.rs
+++ b/src/providers/compatible.rs
@@ -3581,6 +3581,7 @@ mod tests {
         let messages = vec![ChatMessage {
             role: "user".to_string(),
             content: "hello".to_string(),
+            stable_prefix: None,
         }];
         let tools = vec![serde_json::json!({
             "type": "function",

--- a/src/providers/ollama.rs
+++ b/src/providers/ollama.rs
@@ -1168,6 +1168,7 @@ mod tests {
         let messages = vec![ChatMessage {
             role: "assistant".into(),
             content: r#"{"content":null,"tool_calls":[{"id":"call_1","name":"shell","arguments":"{\"command\":\"ls\"}"}]}"#.into(),
+            stable_prefix: None,
         }];
 
         let converted = provider.convert_messages(&messages);
@@ -1192,10 +1193,12 @@ mod tests {
             ChatMessage {
                 role: "assistant".into(),
                 content: r#"{"content":null,"tool_calls":[{"id":"call_7","name":"file_read","arguments":"{\"path\":\"README.md\"}"}]}"#.into(),
+                stable_prefix: None,
             },
             ChatMessage {
                 role: "tool".into(),
                 content: r#"{"tool_call_id":"call_7","content":"ok"}"#.into(),
+                stable_prefix: None,
             },
         ];
 
@@ -1214,6 +1217,7 @@ mod tests {
         let messages = vec![ChatMessage {
             role: "user".into(),
             content: "Inspect this screenshot [IMAGE:data:image/png;base64,abcd==]".into(),
+            stable_prefix: None,
         }];
 
         let converted = provider.convert_messages(&messages);

--- a/src/providers/openai_codex.rs
+++ b/src/providers/openai_codex.rs
@@ -999,18 +999,22 @@ data: [DONE]
             ChatMessage {
                 role: "system".into(),
                 content: "You are helpful.".into(),
+                stable_prefix: None,
             },
             ChatMessage {
                 role: "user".into(),
                 content: "Hi".into(),
+                stable_prefix: None,
             },
             ChatMessage {
                 role: "assistant".into(),
                 content: "Hello!".into(),
+                stable_prefix: None,
             },
             ChatMessage {
                 role: "user".into(),
                 content: "Thanks".into(),
+                stable_prefix: None,
             },
         ];
         let (instructions, input) = build_responses_input(&messages);
@@ -1034,6 +1038,7 @@ data: [DONE]
         let messages = vec![ChatMessage {
             role: "user".into(),
             content: "Hello".into(),
+            stable_prefix: None,
         }];
         let (instructions, input) = build_responses_input(&messages);
         assert_eq!(instructions, DEFAULT_CODEX_INSTRUCTIONS);
@@ -1046,10 +1051,12 @@ data: [DONE]
             ChatMessage {
                 role: "tool".into(),
                 content: "result".into(),
+                stable_prefix: None,
             },
             ChatMessage {
                 role: "user".into(),
                 content: "Go".into(),
+                stable_prefix: None,
             },
         ];
         let (instructions, input) = build_responses_input(&messages);

--- a/src/providers/openrouter.rs
+++ b/src/providers/openrouter.rs
@@ -41,10 +41,22 @@ enum MessageContent {
 }
 
 #[derive(Debug, Serialize)]
+struct CacheControl {
+    #[serde(rename = "type")]
+    cache_type: String,
+}
+
+#[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum MessagePart {
-    Text { text: String },
-    ImageUrl { image_url: ImageUrlPart },
+    Text {
+        text: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
+    },
+    ImageUrl {
+        image_url: ImageUrlPart,
+    },
 }
 
 #[derive(Debug, Serialize)]
@@ -137,6 +149,14 @@ struct UsageInfo {
     prompt_tokens: Option<u64>,
     #[serde(default)]
     completion_tokens: Option<u64>,
+    #[serde(default)]
+    prompt_tokens_details: Option<PromptTokensDetails>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PromptTokensDetails {
+    #[serde(default)]
+    cached_tokens: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -274,6 +294,14 @@ impl OpenRouterProvider {
     }
 
     fn to_message_content(role: &str, content: &str) -> MessageContent {
+        if role == "system" {
+            return MessageContent::Parts(vec![MessagePart::Text {
+                text: content.to_string(),
+                cache_control: Some(CacheControl {
+                    cache_type: "ephemeral".to_string(),
+                }),
+            }]);
+        }
         if role != "user" {
             return MessageContent::Text(content.to_string());
         }
@@ -288,6 +316,7 @@ impl OpenRouterProvider {
         if !trimmed_text.is_empty() {
             parts.push(MessagePart::Text {
                 text: trimmed_text.to_string(),
+                cache_control: None,
             });
         }
 
@@ -532,11 +561,17 @@ impl Provider for OpenRouterProvider {
         let body = Self::read_response_body("OpenRouter", response).await?;
         let native_response =
             Self::parse_response_body::<NativeChatResponse>("OpenRouter", &body, "native chat")?;
-        let usage = native_response.usage.map(|u| TokenUsage {
-            input_tokens: u.prompt_tokens,
-            output_tokens: u.completion_tokens,
-            cached_input_tokens: None,
-            ..Default::default()
+        // OpenRouter cached_tokens = read-only (no creation billing).
+        // cached_input_tokens = read + creation = read + 0.
+        let usage = native_response.usage.map(|u| {
+            let cached = u.prompt_tokens_details.and_then(|d| d.cached_tokens);
+            TokenUsage {
+                input_tokens: u.prompt_tokens,
+                output_tokens: u.completion_tokens,
+                cached_input_tokens: cached,
+                cache_read_input_tokens: cached,
+                cache_creation_input_tokens: None,
+            }
         });
         let message = native_response
             .choices
@@ -624,11 +659,17 @@ impl Provider for OpenRouterProvider {
         let body = Self::read_response_body("OpenRouter", response).await?;
         let native_response =
             Self::parse_response_body::<NativeChatResponse>("OpenRouter", &body, "native chat")?;
-        let usage = native_response.usage.map(|u| TokenUsage {
-            input_tokens: u.prompt_tokens,
-            output_tokens: u.completion_tokens,
-            cached_input_tokens: None,
-            ..Default::default()
+        // OpenRouter cached_tokens = read-only (no creation billing).
+        // cached_input_tokens = read + creation = read + 0.
+        let usage = native_response.usage.map(|u| {
+            let cached = u.prompt_tokens_details.and_then(|d| d.cached_tokens);
+            TokenUsage {
+                input_tokens: u.prompt_tokens,
+                output_tokens: u.completion_tokens,
+                cached_input_tokens: cached,
+                cache_read_input_tokens: cached,
+                cache_creation_input_tokens: None,
+            }
         });
         let message = native_response
             .choices
@@ -717,10 +758,12 @@ mod tests {
             ChatMessage {
                 role: "system".into(),
                 content: "be concise".into(),
+                stable_prefix: None,
             },
             ChatMessage {
                 role: "user".into(),
                 content: "hello".into(),
+                stable_prefix: None,
             },
         ];
 
@@ -764,10 +807,12 @@ mod tests {
             ChatMessage {
                 role: "assistant".into(),
                 content: "Previous answer".into(),
+                stable_prefix: None,
             },
             ChatMessage {
                 role: "user".into(),
                 content: "Follow-up".into(),
+                stable_prefix: None,
             },
         ];
 
@@ -849,6 +894,7 @@ mod tests {
         let messages = vec![ChatMessage {
             role: "user".into(),
             content: "What is the date?".into(),
+            stable_prefix: None,
         }];
         let tools = vec![serde_json::json!({
             "type": "function",
@@ -944,6 +990,7 @@ mod tests {
             role: "assistant".into(),
             content: r#"{"content":"Using tool","tool_calls":[{"id":"call_abc","name":"shell","arguments":"{\"command\":\"pwd\"}"}]}"#
                 .into(),
+            stable_prefix: None,
         }];
 
         let converted = OpenRouterProvider::convert_messages(&messages);
@@ -972,6 +1019,7 @@ mod tests {
         let messages = vec![ChatMessage {
             role: "tool".into(),
             content: r#"{"tool_call_id":"call_xyz","content":"done"}"#.into(),
+            stable_prefix: None,
         }];
 
         let converted = OpenRouterProvider::convert_messages(&messages);
@@ -1023,6 +1071,227 @@ mod tests {
         let json = r#"{"choices": [{"message": {"content": "Hello"}}]}"#;
         let resp: NativeChatResponse = serde_json::from_str(json).unwrap();
         assert!(resp.usage.is_none());
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // prompt caching: response-side deserialization (Unit 1)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    #[test]
+    fn usage_deserializes_cached_tokens() {
+        let json = r#"{
+            "prompt_tokens": 25000,
+            "completion_tokens": 500,
+            "prompt_tokens_details": {"cached_tokens": 20000}
+        }"#;
+        let usage: UsageInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(usage.prompt_tokens, Some(25000));
+        assert_eq!(usage.completion_tokens, Some(500));
+        let details = usage.prompt_tokens_details.unwrap();
+        assert_eq!(details.cached_tokens, Some(20000));
+    }
+
+    #[test]
+    fn usage_deserializes_cached_tokens_zero() {
+        let json = r#"{
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "prompt_tokens_details": {"cached_tokens": 0}
+        }"#;
+        let usage: UsageInfo = serde_json::from_str(json).unwrap();
+        let details = usage.prompt_tokens_details.unwrap();
+        assert_eq!(details.cached_tokens, Some(0));
+    }
+
+    #[test]
+    fn usage_deserializes_without_prompt_tokens_details() {
+        let json = r#"{"prompt_tokens": 100, "completion_tokens": 50}"#;
+        let usage: UsageInfo = serde_json::from_str(json).unwrap();
+        assert!(usage.prompt_tokens_details.is_none());
+    }
+
+    #[test]
+    fn usage_deserializes_empty_prompt_tokens_details() {
+        let json = r#"{
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "prompt_tokens_details": {}
+        }"#;
+        let usage: UsageInfo = serde_json::from_str(json).unwrap();
+        let details = usage.prompt_tokens_details.unwrap();
+        assert!(details.cached_tokens.is_none());
+    }
+
+    #[test]
+    fn native_response_deserializes_with_cached_tokens() {
+        let json = r#"{
+            "choices": [{"message": {"content": "Hello"}}],
+            "usage": {
+                "prompt_tokens": 25000,
+                "completion_tokens": 500,
+                "prompt_tokens_details": {"cached_tokens": 20000}
+            }
+        }"#;
+        let resp: NativeChatResponse = serde_json::from_str(json).unwrap();
+        let usage = resp.usage.unwrap();
+        let details = usage.prompt_tokens_details.unwrap();
+        assert_eq!(details.cached_tokens, Some(20000));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // prompt caching: request-side serialization (Unit 2)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    #[test]
+    fn system_message_serializes_as_content_block_with_cache_control() {
+        let content = OpenRouterProvider::to_message_content("system", "You are helpful.");
+        let json = serde_json::to_value(&content).unwrap();
+        let parts = json.as_array().expect("system content should be an array");
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0]["type"], "text");
+        assert_eq!(parts[0]["text"], "You are helpful.");
+        assert_eq!(parts[0]["cache_control"]["type"], "ephemeral");
+    }
+
+    #[test]
+    fn user_message_serializes_as_plain_string() {
+        let content = OpenRouterProvider::to_message_content("user", "Hello");
+        let json = serde_json::to_value(&content).unwrap();
+        assert!(json.is_string(), "user content should be a plain string");
+        assert_eq!(json.as_str().unwrap(), "Hello");
+    }
+
+    #[test]
+    fn assistant_message_serializes_as_plain_string() {
+        let content = OpenRouterProvider::to_message_content("assistant", "Hi there.");
+        let json = serde_json::to_value(&content).unwrap();
+        assert!(json.is_string(), "assistant content should be a plain string");
+        assert_eq!(json.as_str().unwrap(), "Hi there.");
+    }
+
+    #[test]
+    fn cache_control_not_serialized_for_user_image_text_part() {
+        let content = OpenRouterProvider::to_message_content(
+            "user",
+            "Describe this\n\n[IMAGE:data:image/png;base64,abcd]",
+        );
+        let json = serde_json::to_value(&content).unwrap();
+        let parts = json.as_array().expect("multimodal content should be array");
+        let text_part = &parts[0];
+        assert_eq!(text_part["type"], "text");
+        assert!(
+            text_part.get("cache_control").is_none()
+                || text_part["cache_control"].is_null(),
+            "cache_control should not appear on user image text parts"
+        );
+    }
+
+    #[test]
+    fn full_native_request_serializes_system_as_blocks_user_as_string() {
+        let messages = vec![
+            ChatMessage {
+                role: "system".into(),
+                content: "Be helpful".into(),
+                stable_prefix: None,
+            },
+            ChatMessage {
+                role: "user".into(),
+                content: "Hi".into(),
+                stable_prefix: None,
+            },
+        ];
+        let native = OpenRouterProvider::convert_messages(&messages);
+        assert_eq!(native.len(), 2);
+
+        // System message should be Parts
+        let sys_json = serde_json::to_value(&native[0].content).unwrap();
+        let sys_content = sys_json.as_array().expect("system content should be array");
+        assert_eq!(sys_content[0]["cache_control"]["type"], "ephemeral");
+
+        // User message should be Text
+        let user_json = serde_json::to_value(&native[1].content).unwrap();
+        assert!(user_json.is_string(), "user content should be string");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // prompt caching: response-side token mapping (Unit 3)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    #[test]
+    fn native_response_maps_cached_tokens_to_token_usage() {
+        let json = r#"{
+            "choices": [{"message": {"content": "Hello"}}],
+            "usage": {
+                "prompt_tokens": 25000,
+                "completion_tokens": 500,
+                "prompt_tokens_details": {"cached_tokens": 15000}
+            }
+        }"#;
+        let resp: NativeChatResponse = serde_json::from_str(json).unwrap();
+        let usage = resp.usage.map(|u| {
+            let cached = u.prompt_tokens_details.and_then(|d| d.cached_tokens);
+            TokenUsage {
+                input_tokens: u.prompt_tokens,
+                output_tokens: u.completion_tokens,
+                cached_input_tokens: cached,
+                cache_read_input_tokens: cached,
+                cache_creation_input_tokens: None,
+            }
+        });
+        let usage = usage.unwrap();
+        assert_eq!(usage.input_tokens, Some(25000));
+        assert_eq!(usage.output_tokens, Some(500));
+        assert_eq!(usage.cached_input_tokens, Some(15000));
+        assert_eq!(usage.cache_read_input_tokens, Some(15000));
+        assert!(usage.cache_creation_input_tokens.is_none());
+    }
+
+    #[test]
+    fn native_response_maps_none_when_no_prompt_tokens_details() {
+        let json = r#"{
+            "choices": [{"message": {"content": "Hello"}}],
+            "usage": {"prompt_tokens": 100, "completion_tokens": 50}
+        }"#;
+        let resp: NativeChatResponse = serde_json::from_str(json).unwrap();
+        let usage = resp.usage.map(|u| {
+            let cached = u.prompt_tokens_details.and_then(|d| d.cached_tokens);
+            TokenUsage {
+                input_tokens: u.prompt_tokens,
+                output_tokens: u.completion_tokens,
+                cached_input_tokens: cached,
+                cache_read_input_tokens: cached,
+                cache_creation_input_tokens: None,
+            }
+        });
+        let usage = usage.unwrap();
+        assert!(usage.cached_input_tokens.is_none());
+        assert!(usage.cache_read_input_tokens.is_none());
+    }
+
+    #[test]
+    fn native_response_maps_zero_cached_tokens_as_some_zero() {
+        let json = r#"{
+            "choices": [{"message": {"content": "Hello"}}],
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 50,
+                "prompt_tokens_details": {"cached_tokens": 0}
+            }
+        }"#;
+        let resp: NativeChatResponse = serde_json::from_str(json).unwrap();
+        let usage = resp.usage.map(|u| {
+            let cached = u.prompt_tokens_details.and_then(|d| d.cached_tokens);
+            TokenUsage {
+                input_tokens: u.prompt_tokens,
+                output_tokens: u.completion_tokens,
+                cached_input_tokens: cached,
+                cache_read_input_tokens: cached,
+                cache_creation_input_tokens: None,
+            }
+        });
+        let usage = usage.unwrap();
+        assert_eq!(usage.cached_input_tokens, Some(0));
+        assert_eq!(usage.cache_read_input_tokens, Some(0));
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -1092,6 +1361,7 @@ mod tests {
         let messages = vec![ChatMessage {
             role: "assistant".into(),
             content: history_json.to_string(),
+            stable_prefix: None,
         }];
         let native = OpenRouterProvider::convert_messages(&messages);
         assert_eq!(native.len(), 1);
@@ -1115,6 +1385,7 @@ mod tests {
         let messages = vec![ChatMessage {
             role: "assistant".into(),
             content: history_json.to_string(),
+            stable_prefix: None,
         }];
         let native = OpenRouterProvider::convert_messages(&messages);
         assert_eq!(native.len(), 1);

--- a/src/providers/router.rs
+++ b/src/providers/router.rs
@@ -733,6 +733,7 @@ mod tests {
         let messages = vec![ChatMessage {
             role: "user".to_string(),
             content: "use tools".to_string(),
+            stable_prefix: None,
         }];
         let tools = vec![serde_json::json!({
             "type": "function",
@@ -764,6 +765,7 @@ mod tests {
         let messages = vec![ChatMessage {
             role: "user".to_string(),
             content: "reason about this".to_string(),
+            stable_prefix: None,
         }];
         let tools = vec![serde_json::json!({"type": "function", "function": {"name": "test"}})];
 


### PR DESCRIPTION
## Summary

- Add prompt caching to the OpenRouter provider: `cache_control` on system messages and `cached_tokens` response parsing
- Fix ~40 test compilation errors from missing `stable_prefix` field on `ChatMessage` constructors across 9 test files

## Changes

### Prompt caching (openrouter.rs)

**Request-side:** System messages now serialize as content-block arrays with `cache_control: { type: "ephemeral" }`. Non-system messages remain plain strings. Added `CacheControl` struct and `cache_control: Option<CacheControl>` field on `MessagePart::Text` with `skip_serializing_if`.

**Response-side:** Extended `UsageInfo` with `PromptTokensDetails` (copied from `openai.rs` struct pair). Maps `cached_tokens` to both `cached_input_tokens` and `cache_read_input_tokens` in `TokenUsage` — intentionally diverges from `openai.rs` (which only sets `cached_input_tokens`) so the OTel observer emits `cache_read_input_tokens` to Langfuse.

**Capability:** `ProviderCapabilities.prompt_caching` stays `false` — OpenRouter is a multi-model router where caching is model-dependent.

**13 new unit tests** covering deserialization, serialization, and token mapping.

### Test fixes (9 files)

Added `stable_prefix: None` to ~40 `ChatMessage` test constructors that were missing the field after upstream struct changes. Part of #37.

## Verification

- Deployed to production and verified via Langfuse — `cache_read_input_tokens` field emitted via OTel
- Manual curl test confirmed MiniMax M2.7 caching works: 1,339/1,417 tokens cached on second identical request
- Production code compiles and passes clippy (`cargo check/clippy --lib --features whatsapp-web,observability-otel`)

## Known limitation

Cache hits are currently 0 in production because `stable_prefix` is ignored — system messages mix stable and dynamic content in one block. Tracked as #36 (STORY-009).

## Test plan

- [x] `cargo check --lib --features whatsapp-web,observability-otel` passes
- [x] `cargo clippy --lib --features whatsapp-web` clean
- [x] Binary deployed to remote, daemon starts, all channels healthy
- [x] Langfuse receives `cache_read_input_tokens` via OTel
- [ ] `cargo test` blocked by 16 pre-existing errors in other modules (#37)