### PR TITLE
fix(agent): pin history-trim soft-target contract (#39)

### DIFF
--- a/docs/reference/api/config-reference.md
+++ b/docs/reference/api/config-reference.md
@@ -78,7 +78,8 @@ Operational note for container users:
 |---|---|---|
 | `compact_context` | `true` | When true: bootstrap_max_chars=6000, rag_chunk_limit=2. Use for 13B or smaller models |
 | `max_tool_iterations` | `10` | Maximum tool-call loop turns per user message across CLI, gateway, and channels |
-| `max_history_messages` | `50` | Maximum conversation history messages retained per session |
+| `max_history_messages` | `50` | Soft target for conversation history length per session. Under the default `history_trim_chunked = true`, the buffer is allowed to grow to `2 * max_history_messages` non-system messages before a single batched drain fires and drops back to `max_history_messages` — keeping the conversation prefix byte-stable so the Anthropic message-level cache breakpoint survives across turns. Flip `history_trim_chunked = false` for a strict per-turn cap. |
+| `history_trim_chunked` | `true` | When true (default), trim fires in a single batch once non-system message count crosses `2 * max_history_messages`; preserves the Anthropic message-level prompt-cache prefix across turns. When false, trim fires on every turn that exceeds `max_history_messages` (pre-v0.6 behaviour). |
 | `parallel_tools` | `false` | Enable parallel tool execution within a single iteration |
 | `tool_dispatcher` | `auto` | Tool dispatch strategy |
 | `tool_call_dedup_exempt` | `[]` | Tool names exempt from within-turn duplicate-call suppression |

--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -559,13 +559,17 @@ impl Agent {
             .build()
     }
 
+    /// Drop oldest non-system messages once the buffer has outgrown the
+    /// configured cap. Under chunked mode (default) the cap is a **soft
+    /// target**: no trim fires until non-system count crosses
+    /// `2 * max_history_messages`, then drains back to
+    /// `max_history_messages` in a single batch so the conversation
+    /// prefix stays byte-stable across `max_history_messages` turns and
+    /// the Anthropic message-level cache breakpoint survives. Legacy
+    /// mode (`history_trim_chunked = false`) fires per turn as soon as
+    /// non-system count exceeds `max_history_messages`.
     fn trim_history(&mut self) {
         let max = self.config.max_history_messages;
-        // Chunked mode (default): only fire when the buffer has grown to
-        // `2 * max`, then drain back to `max` in a single batch so the
-        // conversation prefix stays byte-stable for the next `max`
-        // turns. Legacy mode fires as soon as we exceed `max`, which
-        // invalidates the Anthropic message-level cache every turn.
         let threshold = if self.config.history_trim_chunked {
             max.saturating_mul(2)
         } else {

--- a/src/agent/history.rs
+++ b/src/agent/history.rs
@@ -110,14 +110,18 @@ pub(crate) fn estimate_history_tokens(history: &[ChatMessage]) -> usize {
 /// Trim conversation history to prevent unbounded growth.
 /// Preserves the system prompt (first message if role=system) and the most recent messages.
 ///
-/// When `chunked` is true, the trim only fires once the non-system message
-/// count exceeds `2 * max_history`, then drains back down to `max_history`
-/// in a single batch. This keeps the conversation prefix byte-stable for
-/// `max_history` turns at a time, so the Anthropic message-level cache
-/// breakpoint (`apply_cache_to_last_message`) stays valid across turns
-/// instead of being invalidated on every front drop. When `chunked` is
-/// false, the original per-turn behaviour is preserved: drop as soon as
-/// the count exceeds `max_history`.
+/// `max_history` is a **soft target** when `chunked` is true (the default
+/// runtime mode). The effective ceiling is `2 * max_history` non-system
+/// messages: trim is a no-op until the non-system count exceeds that
+/// threshold, then drains back down to `max_history` in a single batch.
+/// This keeps the conversation prefix byte-stable for `max_history` turns
+/// at a time so the Anthropic message-level cache breakpoint
+/// (`apply_cache_to_last_message`) stays valid across turns instead of
+/// being invalidated on every front drop.
+///
+/// When `chunked` is false, `max_history` is a **strict cap**: trim fires
+/// every turn the count exceeds `max_history`, matching the pre-PR-#30
+/// behaviour.
 pub(crate) fn trim_history(
     history: &mut Vec<ChatMessage>,
     max_history: usize,

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -593,17 +593,21 @@ async fn turn_propagates_provider_error() {
 // 8. History trimming during long conversations
 // ═══════════════════════════════════════════════════════════════════════════
 
-// TODO(#39): chunked-trim refactor in PR #30 changed history-trim semantics so
-// the cap is no longer a hard ceiling. Re-enable once #39 settles whether the
-// cap should be strict or the assertion needs to absorb chunk overshoot.
-#[ignore = "see issue #39 — chunked-trim overshoot after PR #30"]
+/// Chunked-mode contract (default): `max_history_messages` is a soft target.
+/// Each turn appends a user+assistant pair, so the buffer grows by 2 per
+/// turn until it crosses the `2 * max_history_messages` threshold, at which
+/// point `Agent::trim_history` drains non-system messages back down to
+/// `max_history_messages` in a single batch. This keeps the conversation
+/// prefix byte-stable for the next `max_history_messages` turns so the
+/// Anthropic message-level cache breakpoint survives across turns.
 #[tokio::test]
 async fn history_trims_after_max_messages() {
     let max_history = 6;
-    let mut responses = vec![];
-    for _ in 0..max_history + 5 {
-        responses.push(text_response("ok"));
-    }
+    // Enough turns to guarantee the chunked drain has fired at least once.
+    // Each turn adds a user + assistant pair; `2 * max_history + 2` turns
+    // push non-system count past the `2 * max_history` threshold.
+    let total_turns = 2 * max_history + 2;
+    let responses: Vec<_> = (0..total_turns).map(|_| text_response("ok")).collect();
 
     let provider = Box::new(ScriptedProvider::new(responses));
     let config = AgentConfig {
@@ -613,20 +617,113 @@ async fn history_trims_after_max_messages() {
 
     let mut agent = build_agent_with_config(provider, vec![], config);
 
-    for i in 0..max_history + 5 {
+    for i in 0..total_turns {
         let _ = agent.turn(&format!("msg {i}")).await.unwrap();
     }
 
-    // System prompt (1) + trimmed messages
-    // Should not exceed max_history + 1 (system prompt)
+    // Effective ceiling under chunked mode: system prompt + at most
+    // `2 * max_history_messages` non-system messages. Beyond this, the
+    // chunked drain must have fired.
+    let effective_ceiling = 1 + 2 * max_history;
     assert!(
-        agent.history().len() <= max_history + 1,
-        "History length {} exceeds max {} + 1 (system)",
+        agent.history().len() <= effective_ceiling,
+        "History length {} exceeds effective ceiling {} (1 + 2 * max_history)",
         agent.history().len(),
-        max_history,
+        effective_ceiling,
     );
 
-    // System prompt should always be preserved
+    // Sanity: without trimming, history would be `1 + 2 * total_turns`.
+    // Assert we are well below that so the trim-fire path is genuinely
+    // exercised (the previous assertion alone would also pass for a buggy
+    // no-op trim that kept everything below the ceiling by chance).
+    let untrimmed_len = 1 + 2 * total_turns;
+    assert!(
+        agent.history().len() < untrimmed_len,
+        "Chunked trim did not fire: history length {} equals untrimmed length {}",
+        agent.history().len(),
+        untrimmed_len,
+    );
+
+    // System prompt is always preserved as the first message.
+    let first = &agent.history()[0];
+    assert!(matches!(first, ConversationMessage::Chat(c) if c.role == "system"));
+}
+
+/// Soft-target contract (R3): within the chunked-mode growth window, trim
+/// is a no-op. Each turn adds a user+assistant pair, so `max_history - 1`
+/// turns leave the buffer at `1 + 2 * (max_history - 1)` messages — still
+/// below the `2 * max_history` threshold that fires the chunked drain.
+/// This property is what keeps the Anthropic message-level cache prefix
+/// byte-stable across `max_history` turns between drains.
+#[tokio::test]
+async fn history_growth_window_does_not_trim_in_chunked_mode() {
+    let max_history = 6;
+    let total_turns = max_history - 1; // stays strictly below the 2*max threshold
+    let responses: Vec<_> = (0..total_turns).map(|_| text_response("ok")).collect();
+
+    let provider = Box::new(ScriptedProvider::new(responses));
+    let config = AgentConfig {
+        max_history_messages: max_history,
+        ..AgentConfig::default()
+    };
+
+    let mut agent = build_agent_with_config(provider, vec![], config);
+
+    for i in 0..total_turns {
+        let _ = agent.turn(&format!("msg {i}")).await.unwrap();
+    }
+
+    // No drain should have fired. History contains the system prompt plus
+    // every user+assistant pair from every turn.
+    let expected = 1 + 2 * total_turns;
+    assert_eq!(
+        agent.history().len(),
+        expected,
+        "Chunked trim fired inside the growth window: history.len()={} but expected {}",
+        agent.history().len(),
+        expected,
+    );
+
+    let first = &agent.history()[0];
+    assert!(matches!(first, ConversationMessage::Chat(c) if c.role == "system"));
+}
+
+/// Legacy strict-cap contract (R4): when `history_trim_chunked` is off,
+/// `Agent::trim_history` reverts to per-turn trimming — the buffer is
+/// drained back to `max_history_messages` as soon as it exceeds the cap,
+/// preserving the pre-PR-#30 behaviour for operators who flip the flag.
+#[tokio::test]
+async fn history_trims_strictly_in_legacy_mode() {
+    let max_history = 6;
+    // Match the historical "max + 5 turns" volume from the chunked test so
+    // a regression that silently re-enables chunked semantics on the
+    // legacy path is caught by this assertion alone.
+    let total_turns = max_history + 5;
+    let responses: Vec<_> = (0..total_turns).map(|_| text_response("ok")).collect();
+
+    let provider = Box::new(ScriptedProvider::new(responses));
+    let config = AgentConfig {
+        max_history_messages: max_history,
+        history_trim_chunked: false,
+        ..AgentConfig::default()
+    };
+
+    let mut agent = build_agent_with_config(provider, vec![], config);
+
+    for i in 0..total_turns {
+        let _ = agent.turn(&format!("msg {i}")).await.unwrap();
+    }
+
+    // Legacy per-turn trim keeps history at the strict cap: system prompt
+    // plus at most `max_history_messages` non-system messages.
+    let strict_cap = 1 + max_history;
+    assert!(
+        agent.history().len() <= strict_cap,
+        "Legacy mode overshot strict cap: history.len()={} exceeds {} (1 + max_history)",
+        agent.history().len(),
+        strict_cap,
+    );
+
     let first = &agent.history()[0];
     assert!(matches!(first, ConversationMessage::Chat(c) if c.role == "system"));
 }


### PR DESCRIPTION
## Summary

- Base branch target (`main`): main
- Problem: Test `agent::tests::history_trims_after_max_messages` was marked `#[ignore]` (see #39) after PR #30 (`06672edb`) changed `trim_history` semantics. Old assertion expected a strict per-turn ceiling; new chunked-mode default keeps the buffer growing up to `2 * max_history_messages` so the Anthropic message-level cache prefix stays byte-stable across turns.
- Why it matters: Re-enabling the test surfaces any future drift on the method-level trim path, and the new companion tests lock the soft-target contract into place so nobody silently re-tightens the ceiling and re-breaks the cache.
- What changed: Un-ignored + rewrote the original test; added two companion tests (growth-window no-op, legacy strict-cap); sharpened doc comments on both trim paths; expanded `config-reference.md` with explicit soft-target semantics and a new `history_trim_chunked` row.
- What did **not** change (scope boundary): No trim logic touched in `src/agent/history.rs` or `src/agent/agent.rs`. No default changes (`history_trim_chunked` stays `true`, `max_history_messages` stays `50`). No new config surface. i18n copies of `config-reference` deferred to a follow-up.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: S`
- Scope labels: `agent, tests, docs`
- Module labels: `agent: history-trim`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: —

## Change Metadata

- Change type: `bug`
- Primary scope: `runtime`

## Linked Issue

- Closes #39
- Related #30 (origin of chunked-trim refactor), #37 (compilation unblock that surfaced this)
- Depends on #: —
- Supersedes #: —

## Validation Evidence (required)

Commands and result summary:

```bash
cargo test --lib --features whatsapp-web 'agent::tests::history_'
# 4 passed; 0 failed (history_trims_after_max_messages, history_growth_window_does_not_trim_in_chunked_mode,
# history_trims_strictly_in_legacy_mode, history_contains_all_expected_entries_after_tool_loop)

cargo test --lib --features whatsapp-web trim_history
# 13 passed; 0 failed (all free-function trim_history tests in agent::loop_::tests)

cargo fmt --all -- --check
# 138 Diff entries — all pre-existing on main (verified by identical count with HEAD stashed).
# No new fmt issues introduced by this PR.

cargo clippy --lib --features whatsapp-web -- -D warnings
# 8 warnings — all pre-existing on main (identical count with HEAD stashed).
# No new clippy warnings introduced by this PR.

cargo doc --lib --no-deps --features whatsapp-web
# Built cleanly. Pre-existing doc warnings unrelated to the touched files.
```

- Evidence provided: test log output above (4/4 history tests + 13/13 free-function tests green)
- If any command is intentionally skipped, explain why: `cargo fmt --all -- --check` and `cargo clippy -- -D warnings` fail on `main` due to pre-existing issues in files this PR does not touch. Verified that this PR introduces zero new fmt/clippy findings (same counts before/after with `git stash`).

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A — tests use `"msg {i}"` placeholders and `"ok"` assistant replies.
- Neutral wording confirmation: Pass — no identity-like wording introduced.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No` (semantics unchanged; only docs clarified)
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? `Yes` (English `config-reference.md` reworded)
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales? `No`
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? `No`
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? `No`
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: i18n sync deferred to a follow-up task to keep this fix small and reviewable. English is authoritative; translations are factually out-of-date for the chunked semantics and will be brought in line in a separate PR.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
  - Un-ignored test failed with the exact symptom in #39 (`History length 11 exceeds max 6 + 1 (system)`) before the rewrite, then passed after.
  - `history_growth_window_does_not_trim_in_chunked_mode` passed on first run, confirming the current code is already honouring the soft-target design (this is the property we wanted to pin).
  - `history_trims_strictly_in_legacy_mode` passed on first run, confirming `Agent::trim_history` honours `history_trim_chunked = false`.
- Edge cases checked:
  - Adjusted the assertion in `history_trims_after_max_messages` to reflect the real behaviour of `Agent::trim_history` (each turn adds a user+assistant pair, not a single message — the ceiling is `1 + 2 * max_history`, not `max_history + 1`).
  - Checked that fmt/clippy warnings reported locally are all pre-existing on `main` (identical counts with and without this PR's diff stashed).
- What was not verified:
  - i18n copies of `config-reference` were not resynced; deferred as noted above.
  - Runtime behaviour against a live Anthropic endpoint (the cache-breakpoint property is exercised by existing free-function tests in `src/agent/loop_::tests`; this PR does not change that code path).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Test suite only for Rust code; `config-reference.md` for docs. No runtime behaviour change.
- Potential unintended effects: None expected — zero production code paths modified.
- Guardrails/monitoring for early detection: CI test runs exercise all four `agent::tests::history_*` tests plus the 13 free-function `trim_history*` tests.

## Agent Collaboration Notes (recommended)

- Agent tools used: `ce:plan`, `ce:work`, `test-driven-development` discipline (Red → Green → Refactor per unit).
- Workflow/plan summary: `docs/plans/2026-04-14-002-fix-history-trim-contract-plan.md` (gitignored).
- Verification focus: Confirmed the test fails the documented way on `main` before rewriting the assertion (TDD Red); verified soft-target no-op and legacy strict-cap paths pass on first run without any production-code changes.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md`): Yes.

## Rollback Plan (required)

- Fast rollback command/path: `git revert 7a317f47` — test + doc changes only; safe to revert in isolation.
- Feature flags or config toggles: `agent.history_trim_chunked` (unchanged default `true`; operators can flip to `false` to get legacy strict-cap behaviour).
- Observable failure symptoms: None expected — no runtime change. If `agent::tests::history_*` start failing post-merge, that indicates an unrelated regression in `Agent::trim_history` or the trim call sites.

## Risks and Mitigations

- Risk: Rewriting the failing test to match current behaviour masks a real regression.
  - Mitigation: TDD Red phase — confirmed the un-ignored test fails with the exact #39 symptom before touching the assertion. The new growth-window and legacy tests were expected to pass on first run; a failure would have halted the unit rather than been papered over.
- Risk: Doc wording drifts from enforced behaviour over time.
  - Mitigation: Unit 4 was sequenced after tests so docs describe what the tests enforce, not the other way around.