### PR TITLE
chore: apply cargo fmt baseline across crate

### DIFF
--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -628,7 +628,10 @@ impl Agent {
                     let outcome_text = if r.success {
                         r.output.clone()
                     } else {
-                        format!("Error: {}", r.error.clone().unwrap_or_else(|| r.output.clone()))
+                        format!(
+                            "Error: {}",
+                            r.error.clone().unwrap_or_else(|| r.output.clone())
+                        )
                     };
                     self.observer.record_event(&ObserverEvent::ToolCall {
                         tool: call.name.clone(),
@@ -662,7 +665,10 @@ impl Agent {
                         let outcome_text = if r.success {
                             r.output.clone()
                         } else {
-                            format!("Error: {}", r.error.clone().unwrap_or_else(|| r.output.clone()))
+                            format!(
+                                "Error: {}",
+                                r.error.clone().unwrap_or_else(|| r.output.clone())
+                            )
                         };
                         self.observer.record_event(&ObserverEvent::ToolCall {
                             tool: call.name.clone(),

--- a/src/agent/history.rs
+++ b/src/agent/history.rs
@@ -122,11 +122,7 @@ pub(crate) fn estimate_history_tokens(history: &[ChatMessage]) -> usize {
 /// When `chunked` is false, `max_history` is a **strict cap**: trim fires
 /// every turn the count exceeds `max_history`, matching the pre-PR-#30
 /// behaviour.
-pub(crate) fn trim_history(
-    history: &mut Vec<ChatMessage>,
-    max_history: usize,
-    chunked: bool,
-) {
+pub(crate) fn trim_history(history: &mut Vec<ChatMessage>, max_history: usize, chunked: bool) {
     let has_system = history.first().map_or(false, |m| m.role == "system");
     let non_system_count = if has_system {
         history.len() - 1

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -2093,12 +2093,14 @@ async fn consume_provider_streaming_response(
             StreamEvent::Usage(usage) => {
                 // Merge streaming usage events (input from message_start,
                 // output from message_delta) into the accumulated usage.
-                let u = outcome.usage.get_or_insert(crate::providers::traits::TokenUsage {
-                    input_tokens: None,
-                    output_tokens: None,
-                    cached_input_tokens: None,
-                    ..Default::default()
-                });
+                let u = outcome
+                    .usage
+                    .get_or_insert(crate::providers::traits::TokenUsage {
+                        input_tokens: None,
+                        output_tokens: None,
+                        cached_input_tokens: None,
+                        ..Default::default()
+                    });
                 if let Some(input) = usage.input_tokens {
                     u.input_tokens = Some(input);
                 }
@@ -2750,9 +2752,8 @@ pub(crate) async fn run_tool_call_loop(
                 // calls) into the observer event so OTel exporters can emit
                 // gen_ai.output.messages and the tool call breakdown.
                 let resp_output_text = resp.text.clone();
-                let resp_output_tool_calls: Vec<
-                    crate::observability::traits::ToolCallSnapshot,
-                > = resp.tool_calls.iter().map(Into::into).collect();
+                let resp_output_tool_calls: Vec<crate::observability::traits::ToolCallSnapshot> =
+                    resp.tool_calls.iter().map(Into::into).collect();
 
                 observer.record_event(&ObserverEvent::LlmResponse {
                     provider: provider_name.to_string(),
@@ -3952,7 +3953,9 @@ pub async fn run(
 
     // Append structured tool-use instructions with schemas (only for non-native providers)
     if !native_tools {
-        parts.stable.push_str(&build_tool_instructions(&tools_registry, Some(&i18n_descs)));
+        parts
+            .stable
+            .push_str(&build_tool_instructions(&tools_registry, Some(&i18n_descs)));
     }
 
     // Append deferred MCP tool names so the LLM knows what is available
@@ -4898,7 +4901,9 @@ pub async fn process_message(
         config.agent.max_system_prompt_chars,
     );
     if !native_tools {
-        parts.stable.push_str(&build_tool_instructions(&tools_registry, Some(&i18n_descs)));
+        parts
+            .stable
+            .push_str(&build_tool_instructions(&tools_registry, Some(&i18n_descs)));
     }
     if !deferred_section.is_empty() {
         parts.stable.push('\n');
@@ -5334,8 +5339,16 @@ mod tests {
             .expect("should produce a sample whose byte index 300 is not a char boundary");
 
         let observer = NoopObserver;
-        let result =
-            execute_one_tool("unknown_tool", call_arguments, None, &[], None, &observer, None).await;
+        let result = execute_one_tool(
+            "unknown_tool",
+            call_arguments,
+            None,
+            &[],
+            None,
+            &observer,
+            None,
+        )
+        .await;
         assert!(result.is_ok(), "execute_one_tool should not panic or error");
 
         let outcome = result.unwrap();
@@ -8980,7 +8993,11 @@ Let me check the result."#;
         trim_history(&mut history, max, true);
 
         // Exactly at 2*max non-system → still no trim in chunked mode.
-        assert_eq!(history.len(), 1 + 2 * max, "chunked mode must not trim at exactly 2*max");
+        assert_eq!(
+            history.len(),
+            1 + 2 * max,
+            "chunked mode must not trim at exactly 2*max"
+        );
         assert_eq!(history[0].role, "system");
     }
 
@@ -8998,7 +9015,11 @@ Let me check the result."#;
         trim_history(&mut history, max, true);
 
         // System preserved, non-system trimmed back down to exactly `max`.
-        assert_eq!(history.len(), 1 + max, "chunked mode must drain down to max");
+        assert_eq!(
+            history.len(),
+            1 + max,
+            "chunked mode must drain down to max"
+        );
         assert_eq!(history[0].role, "system");
         // The oldest surviving non-system message is `msg (max + 1)` —
         // the `max + 1` oldest entries were dropped.
@@ -9026,7 +9047,9 @@ Let me check the result."#;
         // Append turns one at a time up to (but not past) `2 * max` and
         // assert the oldest surviving non-system message stays byte-stable.
         for extra in 0..max {
-            history.push(crate::providers::ChatMessage::user(format!("extra {extra}")));
+            history.push(crate::providers::ChatMessage::user(format!(
+                "extra {extra}"
+            )));
             trim_history(&mut history, max, true);
             assert_eq!(
                 history[1].content, oldest_after_first_trim,

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -172,7 +172,10 @@ struct ChannelNotifyObserver {
 
 impl Observer for ChannelNotifyObserver {
     fn record_event(&self, event: &ObserverEvent) {
-        if let ObserverEvent::ToolCallStart { tool, arguments, .. } = event {
+        if let ObserverEvent::ToolCallStart {
+            tool, arguments, ..
+        } = event
+        {
             self.tools_used.store(true, Ordering::Relaxed);
             let detail = match arguments {
                 Some(args) if !args.is_empty() => {
@@ -1256,9 +1259,7 @@ fn refreshed_new_session_system_prompt(ctx: &ChannelRuntimeContext) -> String {
 /// `## Available Skills` section replaced for the new session (skills
 /// can change when the user runs `/new`). The `dynamic` half is a fresh
 /// `## Current Date & Time` + `## Runtime` block with `now`.
-fn refreshed_new_session_system_prompt_parts(
-    ctx: &ChannelRuntimeContext,
-) -> (String, String) {
+fn refreshed_new_session_system_prompt_parts(ctx: &ChannelRuntimeContext) -> (String, String) {
     let refreshed_skills = crate::skills::skills_to_prompt_with_mode(
         &crate::skills::load_skills_with_config(
             ctx.workspace_dir.as_ref(),
@@ -1273,10 +1274,7 @@ fn refreshed_new_session_system_prompt_parts(
         // monolithic path.
         replace_available_skills_section(ctx.system_prompt.as_str(), &refreshed_skills)
     } else {
-        replace_available_skills_section(
-            ctx.stable_system_prefix.as_str(),
-            &refreshed_skills,
-        )
+        replace_available_skills_section(ctx.stable_system_prefix.as_str(), &refreshed_skills)
     };
     let dynamic = build_dynamic_system_block(ctx.model.as_str());
     (stable, dynamic)
@@ -2915,7 +2913,10 @@ async fn process_channel_message(
     } else if split_active {
         refreshed_new_session_system_prompt_parts(ctx.as_ref())
     } else {
-        (String::new(), refreshed_new_session_system_prompt(ctx.as_ref()))
+        (
+            String::new(),
+            refreshed_new_session_system_prompt(ctx.as_ref()),
+        )
     };
 
     // The dynamic block carries everything that varies per turn:
@@ -2923,8 +2924,7 @@ async fn process_channel_message(
     // and (conditionally) group context. Decorating only the dynamic
     // block keeps the stable prefix byte-identical across turns so the
     // Anthropic cache breakpoint actually hits.
-    dynamic_block =
-        build_channel_system_prompt(&dynamic_block, &msg.channel, &msg.reply_target);
+    dynamic_block = build_channel_system_prompt(&dynamic_block, &msg.channel, &msg.reply_target);
     if !memory_context.is_empty() {
         let _ = write!(dynamic_block, "\n\n{memory_context}");
     }
@@ -2932,17 +2932,15 @@ async fn process_channel_message(
     // For group mentions, inject recent non-mention messages from the
     // observe store so the agent understands the conversation context.
     if msg.reply_target.ends_with("@g.us") {
-        let window = ctx.prompt_config.channels_config.group_context_window_minutes;
+        let window = ctx
+            .prompt_config
+            .channels_config
+            .group_context_window_minutes;
         let max_msgs = ctx.prompt_config.channels_config.group_context_max_messages;
         if window > 0 {
             if let Some(ref obs) = ctx.observe_store {
-                let group_context = load_group_context(
-                    obs,
-                    &msg.reply_target,
-                    window,
-                    max_msgs,
-                    2000,
-                );
+                let group_context =
+                    load_group_context(obs, &msg.reply_target, window, max_msgs, 2000);
                 if !group_context.is_empty() {
                     tracing::info!(
                         channel = %msg.channel,
@@ -12075,7 +12073,14 @@ This is an example JSON object for profile settings."#;
         let recent = now - chrono::Duration::minutes(5);
         {
             let conn_guard = store.conn.lock();
-            for (i, msg) in ["[+111] Hello everyone", "[+222] Anyone know a plumber?", "[+333] Try Pedro"].iter().enumerate() {
+            for (i, msg) in [
+                "[+111] Hello everyone",
+                "[+222] Anyone know a plumber?",
+                "[+333] Try Pedro",
+            ]
+            .iter()
+            .enumerate()
+            {
                 let ts = (recent + chrono::Duration::seconds(i as i64 * 60)).to_rfc3339();
                 conn_guard.execute(
                     "INSERT INTO sessions (session_key, role, content, created_at) VALUES (?1, 'user', ?2, ?3)",
@@ -12181,9 +12186,7 @@ This is an example JSON object for profile settings."#;
     #[tokio::test]
     async fn process_channel_message_injects_group_context_for_mentions() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let observe = Arc::new(
-            session_sqlite::SqliteSessionBackend::new(tmp.path()).unwrap(),
-        );
+        let observe = Arc::new(session_sqlite::SqliteSessionBackend::new(tmp.path()).unwrap());
 
         // Seed observe store with recent group messages
         {
@@ -12309,9 +12312,7 @@ This is an example JSON object for profile settings."#;
     #[tokio::test]
     async fn process_channel_message_skips_group_context_for_dms() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let observe = Arc::new(
-            session_sqlite::SqliteSessionBackend::new(tmp.path()).unwrap(),
-        );
+        let observe = Arc::new(session_sqlite::SqliteSessionBackend::new(tmp.path()).unwrap());
 
         // Seed observe store with messages under a DM-style key (no @g.us)
         {

--- a/src/channels/session_sqlite.rs
+++ b/src/channels/session_sqlite.rs
@@ -155,11 +155,7 @@ impl SqliteSessionBackend {
 
     /// Load the last `n` messages for a session key regardless of time, with timestamps.
     /// Results are returned in chronological order (oldest first).
-    pub fn load_last_n_with_time(
-        &self,
-        session_key: &str,
-        n: usize,
-    ) -> Vec<TimestampedMessage> {
+    pub fn load_last_n_with_time(&self, session_key: &str, n: usize) -> Vec<TimestampedMessage> {
         let conn = self.conn.lock();
         // Select in reverse order then reverse so we get the tail in chronological order.
         let mut stmt = match conn.prepare(

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -354,7 +354,13 @@ enum EditMessageResult {
 }
 
 impl TelegramChannel {
-    pub fn new(bot_token: String, allowed_users: Vec<String>, mention_only: bool, allowed_chats: Vec<String>, allowed_dm_users: Vec<String>) -> Self {
+    pub fn new(
+        bot_token: String,
+        allowed_users: Vec<String>,
+        mention_only: bool,
+        allowed_chats: Vec<String>,
+        allowed_dm_users: Vec<String>,
+    ) -> Self {
         let normalized_allowed = Self::normalize_allowed_users(allowed_users);
         let pairing = if normalized_allowed.is_empty() {
             let guard = PairingGuard::new(true, &[]);
@@ -367,8 +373,10 @@ impl TelegramChannel {
             None
         };
 
-        let mut allowed_chats: Vec<String> =
-            allowed_chats.into_iter().map(|s| s.to_lowercase()).collect();
+        let mut allowed_chats: Vec<String> = allowed_chats
+            .into_iter()
+            .map(|s| s.to_lowercase())
+            .collect();
         allowed_chats.retain(|entry| match entry.as_str() {
             "*" | "dm" | "group" => true,
             id if id.parse::<i64>().is_ok() => true,
@@ -828,12 +836,7 @@ impl TelegramChannel {
             "group" => is_group,
             id => id == chat_id,
         });
-        if !allowed
-            && !is_dm
-            && !is_group
-            && chat_type != "channel"
-            && !chat_type.is_empty()
-        {
+        if !allowed && !is_dm && !is_group && chat_type != "channel" && !chat_type.is_empty() {
             tracing::warn!(
                 "Telegram: unknown chat type '{chat_type}' for chat {chat_id} — not matched by any allowed_chats keyword"
             );
@@ -848,7 +851,11 @@ impl TelegramChannel {
     /// - username or numeric ID — case-insensitive match
     ///
     /// Non-DM chats (groups, supergroups, channels) always pass.
-    fn is_dm_user_allowed(identities: &[&str], chat_type: &str, allowed_dm_users: &[String]) -> bool {
+    fn is_dm_user_allowed(
+        identities: &[&str],
+        chat_type: &str,
+        allowed_dm_users: &[String],
+    ) -> bool {
         if chat_type != "private" {
             return true;
         }
@@ -3246,11 +3253,13 @@ mod tests {
 
     #[test]
     fn supports_draft_updates_respects_stream_mode() {
-        let off = TelegramChannel::new("fake-token".into(), vec!["*".into()], false, vec![], vec![]);
+        let off =
+            TelegramChannel::new("fake-token".into(), vec!["*".into()], false, vec![], vec![]);
         assert!(!off.supports_draft_updates());
 
-        let partial = TelegramChannel::new("fake-token".into(), vec!["*".into()], false, vec![], vec![])
-            .with_streaming(StreamMode::Partial, 750);
+        let partial =
+            TelegramChannel::new("fake-token".into(), vec!["*".into()], false, vec![], vec![])
+                .with_streaming(StreamMode::Partial, 750);
         assert!(partial.supports_draft_updates());
         assert_eq!(partial.draft_update_interval_ms, 750);
     }
@@ -3350,7 +3359,13 @@ mod tests {
 
     #[test]
     fn telegram_user_allowed_specific() {
-        let ch = TelegramChannel::new("t".into(), vec!["alice".into(), "bob".into()], false, vec![], vec![]);
+        let ch = TelegramChannel::new(
+            "t".into(),
+            vec!["alice".into(), "bob".into()],
+            false,
+            vec![],
+            vec![],
+        );
         assert!(ch.is_user_allowed("alice"));
         assert!(!ch.is_user_allowed("eve"));
     }
@@ -3391,7 +3406,13 @@ mod tests {
 
     #[test]
     fn telegram_wildcard_with_specific_users() {
-        let ch = TelegramChannel::new("t".into(), vec!["alice".into(), "*".into()], false, vec![], vec![]);
+        let ch = TelegramChannel::new(
+            "t".into(),
+            vec!["alice".into(), "*".into()],
+            false,
+            vec![],
+            vec![],
+        );
         assert!(ch.is_user_allowed("alice"));
         assert!(ch.is_user_allowed("bob"));
         assert!(ch.is_user_allowed("anyone"));
@@ -3405,7 +3426,13 @@ mod tests {
 
     #[test]
     fn telegram_user_denied_when_none_of_identities_match() {
-        let ch = TelegramChannel::new("t".into(), vec!["alice".into(), "987654321".into()], false, vec![], vec![]);
+        let ch = TelegramChannel::new(
+            "t".into(),
+            vec!["alice".into(), "987654321".into()],
+            false,
+            vec![],
+            vec![],
+        );
         assert!(!ch.is_any_user_allowed(["unknown", "123456789"]));
     }
 
@@ -4223,7 +4250,8 @@ mod tests {
         let ch = TelegramChannel::new("token".into(), vec!["*".into()], true, vec![], vec![]);
         assert!(ch.mention_only);
 
-        let ch_disabled = TelegramChannel::new("token".into(), vec!["*".into()], false, vec![], vec![]);
+        let ch_disabled =
+            TelegramChannel::new("token".into(), vec!["*".into()], false, vec![], vec![]);
         assert!(!ch_disabled.mention_only);
     }
 
@@ -4508,8 +4536,8 @@ mod tests {
         tc.enabled = true;
         tc.api_key = Some("test_key".to_string());
 
-        let ch =
-            TelegramChannel::new("token".into(), vec!["*".into()], false, vec![], vec![]).with_transcription(tc);
+        let ch = TelegramChannel::new("token".into(), vec!["*".into()], false, vec![], vec![])
+            .with_transcription(tc);
         assert!(ch.transcription.is_some());
         assert!(ch.transcription_manager.is_some());
     }
@@ -4517,8 +4545,8 @@ mod tests {
     #[test]
     fn with_transcription_skips_when_disabled() {
         let tc = crate::config::TranscriptionConfig::default(); // enabled = false
-        let ch =
-            TelegramChannel::new("token".into(), vec!["*".into()], false, vec![], vec![]).with_transcription(tc);
+        let ch = TelegramChannel::new("token".into(), vec!["*".into()], false, vec![], vec![])
+            .with_transcription(tc);
         assert!(ch.transcription.is_none());
         assert!(ch.transcription_manager.is_none());
     }
@@ -4546,8 +4574,8 @@ mod tests {
         tc.api_key = Some("test_key".to_string());
         tc.max_duration_secs = 5;
 
-        let ch =
-            TelegramChannel::new("token".into(), vec!["*".into()], false, vec![], vec![]).with_transcription(tc);
+        let ch = TelegramChannel::new("token".into(), vec!["*".into()], false, vec![], vec![])
+            .with_transcription(tc);
         let update = serde_json::json!({
             "message": {
                 "message_id": 2,
@@ -5082,15 +5110,15 @@ mod tests {
 
     #[test]
     fn with_ack_reactions_false_disables_reactions() {
-        let ch =
-            TelegramChannel::new("token".into(), vec!["*".into()], false, vec![], vec![]).with_ack_reactions(false);
+        let ch = TelegramChannel::new("token".into(), vec!["*".into()], false, vec![], vec![])
+            .with_ack_reactions(false);
         assert!(!ch.ack_reactions);
     }
 
     #[test]
     fn with_ack_reactions_true_keeps_reactions() {
-        let ch =
-            TelegramChannel::new("token".into(), vec!["*".into()], false, vec![], vec![]).with_ack_reactions(true);
+        let ch = TelegramChannel::new("token".into(), vec!["*".into()], false, vec![], vec![])
+            .with_ack_reactions(true);
         assert!(ch.ack_reactions);
     }
 
@@ -5247,7 +5275,11 @@ mod tests {
     fn is_chat_allowed_empty_allows_all() {
         assert!(TelegramChannel::is_chat_allowed("123", "private", &[]));
         assert!(TelegramChannel::is_chat_allowed("-100999", "group", &[]));
-        assert!(TelegramChannel::is_chat_allowed("-100999", "supergroup", &[]));
+        assert!(TelegramChannel::is_chat_allowed(
+            "-100999",
+            "supergroup",
+            &[]
+        ));
     }
 
     #[test]
@@ -5261,8 +5293,14 @@ mod tests {
     fn is_chat_allowed_dm_keyword() {
         let chats = vec!["dm".to_string()];
         assert!(TelegramChannel::is_chat_allowed("123", "private", &chats));
-        assert!(!TelegramChannel::is_chat_allowed("-100999", "group", &chats));
-        assert!(!TelegramChannel::is_chat_allowed("-100999", "supergroup", &chats));
+        assert!(!TelegramChannel::is_chat_allowed(
+            "-100999", "group", &chats
+        ));
+        assert!(!TelegramChannel::is_chat_allowed(
+            "-100999",
+            "supergroup",
+            &chats
+        ));
     }
 
     #[test]
@@ -5270,14 +5308,26 @@ mod tests {
         let chats = vec!["group".to_string()];
         assert!(!TelegramChannel::is_chat_allowed("123", "private", &chats));
         assert!(TelegramChannel::is_chat_allowed("-100999", "group", &chats));
-        assert!(TelegramChannel::is_chat_allowed("-100999", "supergroup", &chats));
+        assert!(TelegramChannel::is_chat_allowed(
+            "-100999",
+            "supergroup",
+            &chats
+        ));
     }
 
     #[test]
     fn is_chat_allowed_explicit_chat_id() {
         let chats = vec!["-1001234567890".to_string()];
-        assert!(TelegramChannel::is_chat_allowed("-1001234567890", "supergroup", &chats));
-        assert!(!TelegramChannel::is_chat_allowed("-100999", "supergroup", &chats));
+        assert!(TelegramChannel::is_chat_allowed(
+            "-1001234567890",
+            "supergroup",
+            &chats
+        ));
+        assert!(!TelegramChannel::is_chat_allowed(
+            "-100999",
+            "supergroup",
+            &chats
+        ));
         assert!(!TelegramChannel::is_chat_allowed("123", "private", &chats));
     }
 
@@ -5292,13 +5342,21 @@ mod tests {
     #[test]
     fn is_chat_allowed_channel_type_needs_explicit_id_or_star() {
         let keywords_only = vec!["dm".to_string(), "group".to_string()];
-        assert!(!TelegramChannel::is_chat_allowed("-100123", "channel", &keywords_only));
+        assert!(!TelegramChannel::is_chat_allowed(
+            "-100123",
+            "channel",
+            &keywords_only
+        ));
 
         let with_star = vec!["*".to_string()];
-        assert!(TelegramChannel::is_chat_allowed("-100123", "channel", &with_star));
+        assert!(TelegramChannel::is_chat_allowed(
+            "-100123", "channel", &with_star
+        ));
 
         let with_id = vec!["-100123".to_string()];
-        assert!(TelegramChannel::is_chat_allowed("-100123", "channel", &with_id));
+        assert!(TelegramChannel::is_chat_allowed(
+            "-100123", "channel", &with_id
+        ));
     }
 
     #[test]
@@ -5310,59 +5368,131 @@ mod tests {
             .collect();
         assert!(TelegramChannel::is_chat_allowed("123", "private", &chats));
         assert!(TelegramChannel::is_chat_allowed("-100999", "group", &chats));
-        assert!(TelegramChannel::is_chat_allowed("-100999", "supergroup", &chats));
+        assert!(TelegramChannel::is_chat_allowed(
+            "-100999",
+            "supergroup",
+            &chats
+        ));
     }
 
     #[test]
     fn is_dm_user_allowed_empty_allows_all() {
-        assert!(TelegramChannel::is_dm_user_allowed(&["alice"], "private", &[]));
-        assert!(TelegramChannel::is_dm_user_allowed(&["alice"], "group", &[]));
+        assert!(TelegramChannel::is_dm_user_allowed(
+            &["alice"],
+            "private",
+            &[]
+        ));
+        assert!(TelegramChannel::is_dm_user_allowed(
+            &["alice"],
+            "group",
+            &[]
+        ));
     }
 
     #[test]
     fn is_dm_user_allowed_star_allows_all_dms() {
         let users = vec!["*".to_string()];
-        assert!(TelegramChannel::is_dm_user_allowed(&["alice"], "private", &users));
+        assert!(TelegramChannel::is_dm_user_allowed(
+            &["alice"],
+            "private",
+            &users
+        ));
     }
 
     #[test]
     fn is_dm_user_allowed_specific_user() {
         let users = vec!["alice".to_string()];
-        assert!(TelegramChannel::is_dm_user_allowed(&["alice"], "private", &users));
-        assert!(!TelegramChannel::is_dm_user_allowed(&["bob"], "private", &users));
+        assert!(TelegramChannel::is_dm_user_allowed(
+            &["alice"],
+            "private",
+            &users
+        ));
+        assert!(!TelegramChannel::is_dm_user_allowed(
+            &["bob"],
+            "private",
+            &users
+        ));
     }
 
     #[test]
     fn is_dm_user_allowed_by_numeric_id() {
         let users = vec!["2852312".to_string()];
-        assert!(TelegramChannel::is_dm_user_allowed(&["unknown", "2852312"], "private", &users));
-        assert!(!TelegramChannel::is_dm_user_allowed(&["unknown", "999"], "private", &users));
+        assert!(TelegramChannel::is_dm_user_allowed(
+            &["unknown", "2852312"],
+            "private",
+            &users
+        ));
+        assert!(!TelegramChannel::is_dm_user_allowed(
+            &["unknown", "999"],
+            "private",
+            &users
+        ));
     }
 
     #[test]
     fn is_dm_user_allowed_non_dm_always_passes() {
         let users = vec!["alice".to_string()];
-        assert!(TelegramChannel::is_dm_user_allowed(&["bob"], "group", &users));
-        assert!(TelegramChannel::is_dm_user_allowed(&["bob"], "supergroup", &users));
-        assert!(TelegramChannel::is_dm_user_allowed(&["bob"], "channel", &users));
+        assert!(TelegramChannel::is_dm_user_allowed(
+            &["bob"],
+            "group",
+            &users
+        ));
+        assert!(TelegramChannel::is_dm_user_allowed(
+            &["bob"],
+            "supergroup",
+            &users
+        ));
+        assert!(TelegramChannel::is_dm_user_allowed(
+            &["bob"],
+            "channel",
+            &users
+        ));
     }
 
     #[test]
     fn is_dm_user_allowed_mixed_users() {
         let users = vec!["alice".to_string(), "2852312".to_string()];
-        assert!(TelegramChannel::is_dm_user_allowed(&["alice"], "private", &users));
-        assert!(TelegramChannel::is_dm_user_allowed(&["unknown", "2852312"], "private", &users));
-        assert!(!TelegramChannel::is_dm_user_allowed(&["bob", "999"], "private", &users));
+        assert!(TelegramChannel::is_dm_user_allowed(
+            &["alice"],
+            "private",
+            &users
+        ));
+        assert!(TelegramChannel::is_dm_user_allowed(
+            &["unknown", "2852312"],
+            "private",
+            &users
+        ));
+        assert!(!TelegramChannel::is_dm_user_allowed(
+            &["bob", "999"],
+            "private",
+            &users
+        ));
     }
 
     #[test]
     fn is_dm_user_allowed_case_insensitive() {
         // Constructor lowercases entries, so simulate that
         let users = vec!["alice".to_string()]; // would be "Alice" in config, lowered by constructor
-        assert!(TelegramChannel::is_dm_user_allowed(&["Alice"], "private", &users));
-        assert!(TelegramChannel::is_dm_user_allowed(&["ALICE"], "private", &users));
-        assert!(TelegramChannel::is_dm_user_allowed(&["alice"], "private", &users));
-        assert!(!TelegramChannel::is_dm_user_allowed(&["bob"], "private", &users));
+        assert!(TelegramChannel::is_dm_user_allowed(
+            &["Alice"],
+            "private",
+            &users
+        ));
+        assert!(TelegramChannel::is_dm_user_allowed(
+            &["ALICE"],
+            "private",
+            &users
+        ));
+        assert!(TelegramChannel::is_dm_user_allowed(
+            &["alice"],
+            "private",
+            &users
+        ));
+        assert!(!TelegramChannel::is_dm_user_allowed(
+            &["bob"],
+            "private",
+            &users
+        ));
     }
 
     #[test]
@@ -5383,7 +5513,13 @@ mod tests {
             "t".into(),
             vec!["*".into()],
             false,
-            vec!["group".to_string(), "groups".to_string(), "dm".to_string(), "bogus".to_string(), "-100123".to_string()],
+            vec![
+                "group".to_string(),
+                "groups".to_string(),
+                "dm".to_string(),
+                "bogus".to_string(),
+                "-100123".to_string(),
+            ],
             vec![],
         );
         // "groups" and "bogus" should be dropped; "group", "dm", "-100123" kept
@@ -5397,7 +5533,12 @@ mod tests {
             vec!["*".into()],
             false,
             vec![],
-            vec!["alice".to_string(), "has spaces".to_string(), "*".to_string(), "123".to_string()],
+            vec![
+                "alice".to_string(),
+                "has spaces".to_string(),
+                "*".to_string(),
+                "123".to_string(),
+            ],
         );
         // "has spaces" gets normalized (trim) but still contains a space → dropped
         // "has" won't be there because normalize_identity doesn't split; the space makes it invalid

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -6344,8 +6344,12 @@ fn default_channel_message_timeout_secs() -> u64 {
     300
 }
 
-fn default_group_context_window_minutes() -> u64 { 15 }
-fn default_group_context_max_messages() -> usize { 30 }
+fn default_group_context_window_minutes() -> u64 {
+    15
+}
+fn default_group_context_max_messages() -> usize {
+    30
+}
 
 fn default_session_backend() -> String {
     "sqlite".into()

--- a/src/memory/sqlite.rs
+++ b/src/memory/sqlite.rs
@@ -2470,7 +2470,7 @@ mod tests {
             None,
             Some("ns1"),
             None,
-                None,
+            None,
         )
         .await
         .unwrap();
@@ -2481,7 +2481,7 @@ mod tests {
             None,
             Some("ns2"),
             None,
-                None,
+            None,
         )
         .await
         .unwrap();
@@ -2572,7 +2572,7 @@ mod tests {
             Some("sess-a"),
             Some("ns1"),
             None,
-                None,
+            None,
         )
         .await
         .unwrap();
@@ -2583,7 +2583,7 @@ mod tests {
             Some("sess-a"),
             Some("ns2"),
             None,
-                None,
+            None,
         )
         .await
         .unwrap();
@@ -2594,7 +2594,7 @@ mod tests {
             None,
             Some("ns1"),
             None,
-                None,
+            None,
         )
         .await
         .unwrap();
@@ -2650,7 +2650,7 @@ mod tests {
             Some("sess-rt"),
             Some("ns-rt"),
             Some(0.9),
-                None,
+            None,
         )
         .await
         .unwrap();

--- a/src/observability/otel.rs
+++ b/src/observability/otel.rs
@@ -266,16 +266,10 @@ impl Observer for OtelObserver {
                 // and the granular gen_ai.usage.cache_{read,creation}_input_tokens
                 // breakdown so Langfuse can compute cache pricing correctly.
                 if let Some(it) = input_tokens {
-                    span_attrs.push(KeyValue::new(
-                        "gen_ai.usage.input_tokens",
-                        *it as i64,
-                    ));
+                    span_attrs.push(KeyValue::new("gen_ai.usage.input_tokens", *it as i64));
                 }
                 if let Some(ot) = output_tokens {
-                    span_attrs.push(KeyValue::new(
-                        "gen_ai.usage.output_tokens",
-                        *ot as i64,
-                    ));
+                    span_attrs.push(KeyValue::new("gen_ai.usage.output_tokens", *ot as i64));
                 }
                 if let Some(cr) = cache_read_input_tokens {
                     span_attrs.push(KeyValue::new(
@@ -306,10 +300,7 @@ impl Observer for OtelObserver {
                 // Full system prompt — single attribute (not an array)
                 // matching OTel's gen_ai.system_instructions convention.
                 if let Some(sp) = system_prompt {
-                    span_attrs.push(KeyValue::new(
-                        "gen_ai.system_instructions",
-                        sp.clone(),
-                    ));
+                    span_attrs.push(KeyValue::new("gen_ai.system_instructions", sp.clone()));
                 }
 
                 // Full input messages — JSON-encoded array of {role, content}
@@ -331,10 +322,7 @@ impl Observer for OtelObserver {
                 )
                 .unwrap_or_else(|_| "[]".to_string());
                 if input_messages_json != "[]" {
-                    span_attrs.push(KeyValue::new(
-                        "gen_ai.input.messages",
-                        input_messages_json,
-                    ));
+                    span_attrs.push(KeyValue::new("gen_ai.input.messages", input_messages_json));
                 }
 
                 // Tool definitions — JSON-encoded array. Langfuse renders
@@ -396,9 +384,12 @@ impl Observer for OtelObserver {
                         serde_json::Value::Array(tool_calls_json),
                     );
                 }
-                let output_messages_json = serde_json::to_string(&vec![output_msg])
-                    .unwrap_or_else(|_| "[]".to_string());
-                span_attrs.push(KeyValue::new("gen_ai.output.messages", output_messages_json));
+                let output_messages_json =
+                    serde_json::to_string(&vec![output_msg]).unwrap_or_else(|_| "[]".to_string());
+                span_attrs.push(KeyValue::new(
+                    "gen_ai.output.messages",
+                    output_messages_json,
+                ));
 
                 let mut span = tracer.build(
                     opentelemetry::trace::SpanBuilder::from_name("llm.call")
@@ -490,19 +481,13 @@ impl Observer for OtelObserver {
                     span_attrs.push(KeyValue::new("gen_ai.tool.call.id", id.clone()));
                 }
                 if let Some(args) = arguments {
-                    span_attrs.push(KeyValue::new(
-                        "gen_ai.tool.arguments",
-                        args.clone(),
-                    ));
+                    span_attrs.push(KeyValue::new("gen_ai.tool.arguments", args.clone()));
                     // Also stash as Langfuse-native input field so the UI
                     // shows it in the Input pane.
                     span_attrs.push(KeyValue::new("input.value", args.clone()));
                 }
                 if let Some(res) = result {
-                    span_attrs.push(KeyValue::new(
-                        "gen_ai.tool.result",
-                        res.clone(),
-                    ));
+                    span_attrs.push(KeyValue::new("gen_ai.tool.result", res.clone()));
                     span_attrs.push(KeyValue::new("output.value", res.clone()));
                 }
 

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -3876,8 +3876,12 @@ fn setup_channels(existing: Option<ChannelsConfig>) -> Result<ChannelsConfig> {
                     mention_only: existing_tg.map(|t| t.mention_only).unwrap_or(false),
                     ack_reactions: existing_tg.and_then(|t| t.ack_reactions),
                     proxy_url: existing_tg.and_then(|t| t.proxy_url.clone()),
-                    allowed_chats: existing_tg.map(|t| t.allowed_chats.clone()).unwrap_or_default(),
-                    allowed_dm_users: existing_tg.map(|t| t.allowed_dm_users.clone()).unwrap_or_default(),
+                    allowed_chats: existing_tg
+                        .map(|t| t.allowed_chats.clone())
+                        .unwrap_or_default(),
+                    allowed_dm_users: existing_tg
+                        .map(|t| t.allowed_dm_users.clone())
+                        .unwrap_or_default(),
                 });
             }
             ChannelMenuChoice::Discord => {

--- a/src/providers/claude_code.rs
+++ b/src/providers/claude_code.rs
@@ -200,8 +200,12 @@ impl ClaudeCodeProvider {
                     input_tokens: u.get("input_tokens").and_then(|v| v.as_u64()),
                     output_tokens: u.get("output_tokens").and_then(|v| v.as_u64()),
                     cached_input_tokens: u.get("cache_read_input_tokens").and_then(|v| v.as_u64()),
-                    cache_read_input_tokens: u.get("cache_read_input_tokens").and_then(|v| v.as_u64()),
-                    cache_creation_input_tokens: u.get("cache_creation_input_tokens").and_then(|v| v.as_u64()),
+                    cache_read_input_tokens: u
+                        .get("cache_read_input_tokens")
+                        .and_then(|v| v.as_u64()),
+                    cache_creation_input_tokens: u
+                        .get("cache_creation_input_tokens")
+                        .and_then(|v| v.as_u64()),
                 });
 
                 return Ok((text, usage));

--- a/src/providers/openrouter.rs
+++ b/src/providers/openrouter.rs
@@ -223,11 +223,7 @@ impl OpenRouterProvider {
                 },
             })
             .collect();
-        if valid.is_empty() {
-            None
-        } else {
-            Some(valid)
-        }
+        if valid.is_empty() { None } else { Some(valid) }
     }
 
     fn convert_messages(messages: &[ChatMessage]) -> Vec<NativeMessage> {
@@ -693,11 +689,7 @@ impl Provider for OpenRouterProvider {
                     })
                 })
                 .collect();
-            if specs.is_empty() {
-                None
-            } else {
-                Some(specs)
-            }
+            if specs.is_empty() { None } else { Some(specs) }
         };
 
         // Convert ChatMessage to NativeMessage, preserving structured assistant/tool entries

--- a/src/providers/traits.rs
+++ b/src/providers/traits.rs
@@ -578,7 +578,13 @@ pub trait Provider: Send + Sync {
             .rfind(|m| m.role == "user")
             .map(|m| m.content.as_str())
             .unwrap_or("");
-        self.stream_chat_with_system(system_owned.as_deref(), last_user, model, temperature, options)
+        self.stream_chat_with_system(
+            system_owned.as_deref(),
+            last_user,
+            model,
+            temperature,
+            options,
+        )
     }
 
     /// Structured streaming chat interface.


### PR DESCRIPTION
## Summary

- Base branch target (`main`): main
- Problem: `cargo fmt --all -- --check` has reported 138 diffs across 13 files on `main` for a while. The PR template requires this command as validation evidence, so every PR either has to skip it (as #42 did) or include formatting noise unrelated to the change under review.
- Why it matters: Unblocks the CI fmt gate referenced in `.github/pull_request_template.md` and lets future PRs cleanly report `cargo fmt --all -- --check` as part of validation evidence without accumulating more per-PR noise.
- What changed: Pure `cargo fmt --all` output. Whitespace, line-break, and argument-list reflows only.
- What did **not** change (scope boundary): Zero logic. No new imports, no signature changes, no behavioural diff. Clippy warnings and unused-code cleanups are explicitly **not** in this PR — a follow-up handles those.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: L` (by line count; 100% mechanical)
- Scope labels: `core`
- Module labels: N/A (cross-cutting cargo fmt sweep)
- Contributor tier label: (auto-managed)

## Change Metadata

- Change type: `chore`
- Primary scope: `multi`

## Linked Issue

- Closes #: —
- Related #: #42 (which noted the 138 pre-existing diffs as skip-reason in validation evidence)

## Validation Evidence (required)

```bash
cargo fmt --all
# Auto-fix applied across the tree.

cargo fmt --all -- --check
# 0 diffs. (Was 138 before this PR.)

cargo build --lib --features whatsapp-web
# Finished `dev` profile — builds cleanly.

cargo test --lib --features whatsapp-web history_trims
# 2 passed: agent::tests::history_trims_after_max_messages,
#            agent::tests::history_trims_strictly_in_legacy_mode

cargo test --lib --features whatsapp-web trim_history
# 13 passed (all agent::loop_::tests::trim_history_* variants).
```

- Evidence provided: `cargo fmt --all -- --check` exit 0; build + 15 trim-path tests green.
- If any command is intentionally skipped, explain why: `cargo clippy --all-targets -- -D warnings` still fails on `main` due to 8 pre-existing warnings in files this PR does not touch. Those are addressed by a separate follow-up PR so the judgment-call fixes stay out of this mechanical sweep.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A — only whitespace reflows.
- Neutral wording confirmation: Pass.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? `No` — code-only change, no user-facing wording.

## Human Verification (required)

- Verified scenarios:
  - `cargo fmt --all -- --check` count dropped from 138 to 0.
  - Crate still builds with `whatsapp-web` feature.
  - Trim-path tests (the ones exercised by #42) all pass.
- Edge cases checked:
  - Diff spot-checked in `src/agent/*`, `src/channels/*`, `src/config/schema.rs`, `src/providers/*`, `src/memory/sqlite.rs`, `src/observability/otel.rs`, `src/onboard/wizard.rs` — all changes are pure formatting (indent, line wrap, trailing commas).
- What was not verified:
  - Did not run the full crate test suite (`cargo test --all --features whatsapp-web`) locally due to time; mechanical fmt output has very low regression risk. CI will catch anything.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Source formatting only. Zero runtime behaviour change.
- Potential unintended effects: None expected.
- Guardrails/monitoring for early detection: CI test run on this PR.

## Agent Collaboration Notes (recommended)

- Agent tools used: `cargo fmt --all`.
- Workflow/plan summary: Split cleanup of 138 fmt diffs + 8 clippy warnings into two PRs — this one is mechanical fmt only; clippy cleanup follows.
- Verification focus: fmt-check delta (138 → 0) and that nothing broke in the trim-path tests touched by #42.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md`): Yes.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge-sha>` — pure whitespace revert, safe in isolation.
- Feature flags or config toggles: None.
- Observable failure symptoms: Compile/test failure would appear immediately in CI; no runtime symptoms possible.

## Risks and Mitigations

- Risk: `cargo fmt` reflow accidentally masks a deliberate formatting choice (e.g., aligned comments, custom indent).
  - Mitigation: Diff is spot-checked across the 13 touched files; all changes are `rustfmt` defaults, no stylistic overrides exist in the repo. If a specific block needs preservation, a `#[rustfmt::skip]` can be added in a follow-up without losing the rest of the baseline.