### PR TITLE
chore: clear clippy warnings across lib + in-source tests

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -9008,7 +9008,7 @@ Let me check the result."#;
     fn trim_history_chunked_fires_above_double_threshold() {
         let max = 10;
         let mut history = vec![crate::providers::ChatMessage::system("sys")];
-        for i in 0..(2 * max + 1) {
+        for i in 0..=(2 * max) {
             history.push(crate::providers::ChatMessage::user(format!("msg {i}")));
         }
 
@@ -9035,7 +9035,7 @@ Let me check the result."#;
     fn trim_history_chunked_oldest_stable_between_trims() {
         let max = 4;
         let mut history = vec![crate::providers::ChatMessage::system("sys")];
-        for i in 0..(2 * max + 1) {
+        for i in 0..=(2 * max) {
             history.push(crate::providers::ChatMessage::user(format!("msg {i}")));
         }
 
@@ -9065,7 +9065,7 @@ Let me check the result."#;
     fn trim_history_legacy_per_turn_behaviour() {
         let max = 10;
         let mut history = vec![crate::providers::ChatMessage::system("sys")];
-        for i in 0..(max + 1) {
+        for i in 0..=max {
             history.push(crate::providers::ChatMessage::user(format!("msg {i}")));
         }
 

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -5582,7 +5582,7 @@ mod tests {
                 "message_id": 1,
                 "text": "hello",
                 "from": { "id": 1, "username": "alice" },
-                "chat": { "id": -100999, "type": "supergroup" }
+                "chat": { "id": -100_999, "type": "supergroup" }
             }
         });
         assert!(ch.parse_update_message(&update).is_some());
@@ -5602,7 +5602,7 @@ mod tests {
                 "message_id": 1,
                 "text": "hello",
                 "from": { "id": 1, "username": "alice" },
-                "chat": { "id": -100999, "type": "supergroup" }
+                "chat": { "id": -100_999, "type": "supergroup" }
             }
         });
         assert!(ch.parse_update_message(&update).is_some());
@@ -5662,7 +5662,7 @@ mod tests {
                 "message_id": 1,
                 "text": "hello",
                 "from": { "id": 999, "username": "bob" },
-                "chat": { "id": -100999, "type": "supergroup" }
+                "chat": { "id": -100_999, "type": "supergroup" }
             }
         });
         assert!(ch.parse_update_message(&update).is_some());

--- a/src/channels/whatsapp_storage.rs
+++ b/src/channels/whatsapp_storage.rs
@@ -36,7 +36,10 @@ use wa_rs_core::store::traits::DeviceInfo;
 #[cfg(feature = "whatsapp-web")]
 use wa_rs_core::store::traits::DeviceStore as DeviceStoreTrait;
 #[cfg(feature = "whatsapp-web")]
-use wa_rs_core::store::traits::*;
+use wa_rs_core::store::traits::{
+    AppStateSyncKey, AppSyncStore, DeviceListRecord, LidPnMappingEntry, ProtocolStore, SignalStore,
+    TcTokenEntry,
+};
 
 /// Custom wa-rs storage backend using rusqlite
 ///
@@ -1121,8 +1124,8 @@ impl DeviceStoreTrait for RusqliteStore {
                 device.app_version_secondary,
                 device.app_version_tertiary,
                 device.app_version_last_fetched_ms,
-                device.edge_routing_info.as_ref().map(|v| v.clone()),
-                device.props_hash.as_ref().map(|v| v.clone()),
+                device.edge_routing_info.clone(),
+                device.props_hash.clone(),
             ],
         ))
     }

--- a/src/channels/whatsapp_web.rs
+++ b/src/channels/whatsapp_web.rs
@@ -1065,7 +1065,9 @@ impl Channel for WhatsAppWebChannel {
             ..Default::default()
         };
 
-        let message_id = client.send_message(to, outgoing).await?;
+        // Box::pin the large future (~34KB) so it doesn't inflate the
+        // enclosing Send future's stack slot — clippy::large_futures.
+        let message_id = Box::pin(client.send_message(to, outgoing)).await?;
         tracing::debug!(
             "WhatsApp Web: sent text to {} (id: {})",
             message.recipient,
@@ -1114,7 +1116,7 @@ impl Channel for WhatsAppWebChannel {
                 tracing::info!(
                     "WhatsApp Web: no existing session, new device will be created during pairing"
                 );
-            };
+            }
 
             // Create transport factory
             let mut transport_factory = TokioWebSocketTransportFactory::new();
@@ -1561,7 +1563,7 @@ impl Channel for WhatsAppWebChannel {
                                         // resolved phone JID (see above).
                                         reply_target,
                                         content,
-                                        timestamp: chrono::Utc::now().timestamp() as u64,
+                                        timestamp: chrono::Utc::now().timestamp().cast_unsigned(),
                                         thread_ts: None,
                                         interruption_scope_id: None,
                     attachments: vec![],
@@ -2074,7 +2076,7 @@ mod tests {
         // attempt 1 → 3s, 2 → 6s, 3 → 12s, … 7 → 192s, 8 → 300s (capped)
         let expected = [3, 6, 12, 24, 48, 96, 192, 300, 300, 300];
         for (i, &want) in expected.iter().enumerate() {
-            let attempt = (i + 1) as u32;
+            let attempt = u32::try_from(i + 1).expect("test index within u32 range");
             assert_eq!(
                 WhatsAppWebChannel::compute_retry_delay(attempt),
                 want,

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1311,6 +1311,12 @@ fn default_local_whisper_timeout_secs() -> u64 {
 }
 
 /// Agent orchestration configuration (`[agent]` section).
+// AgentConfig intentionally carries several independent boolean toggles
+// (`compact_context`, `history_trim_chunked`, `parallel_tools`,
+// `context_aware_tools`, ...). These are orthogonal user-facing switches,
+// not a state machine — refactoring them into an enum would obscure the
+// config surface without simplifying runtime logic.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct AgentConfig {
     /// When true: bootstrap_max_chars=6000, rag_chunk_limit=2. Use for 13B or smaller models.


### PR DESCRIPTION
## Summary

- Base branch target (`main`): main
- Problem: `cargo clippy --lib --features whatsapp-web -- -D warnings` reported 8 distinct findings on main — a mix of trivial auto-fixable lints and a few real design calls (wildcard import, 34KB `send_message` future, `AgentConfig` with more than 3 booleans).
- Why it matters: Together with #43 (fmt baseline), this clears the CI validation surface referenced in the PR template so future PRs can honestly include `cargo clippy --all-targets -- -D warnings` in their evidence instead of skipping it.
- What changed: Per-warning fixes with rationale. No behavioural changes; only lint-compliance rewrites (inclusive ranges, explicit imports, `.clone()` direct, `Box::pin`, `cast_unsigned`, `u32::try_from`, literal separators) plus one scoped `#[allow]` attribute on `AgentConfig`.
- What did **not** change (scope boundary): Integration-test compile failures under `--all-targets` (E0063 `TokenUsage` missing fields, E0061 `TelegramChannel::new` arity drift in `tests/*.rs`) are **not** addressed here — those are upstream API catch-ups, not lint fixes. Separate follow-up.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: S`
- Scope labels: `agent, channel, config, tests`
- Module labels: `channel: telegram`, `channel: whatsapp`
- Contributor tier label: (auto-managed)

## Change Metadata

- Change type: `chore`
- Primary scope: `multi`

## Linked Issue

- Closes #: —
- Related #: #43 (fmt baseline), #42 (original reference to the 8 pre-existing clippy warnings)

## Per-Warning Breakdown

| Warning | File:Line | Fix |
|---|---|---|
| `long_literal_lacking_separators` ×3 | `src/channels/telegram.rs` | `-100999` → `-100_999` (value unchanged) |
| `wildcard_imports` | `src/channels/whatsapp_storage.rs:39` | Replace `traits::*` with explicit 7-trait list |
| `useless_asref` ×2 | `src/channels/whatsapp_storage.rs:1124-1125` | `.as_ref().map(\|v\| v.clone())` → `.clone()` on `Option<T: Clone>` |
| `large_futures` (34 744 B) | `src/channels/whatsapp_web.rs:1068` | `Box::pin(client.send_message(...))` |
| `unnecessary_semicolon` | `src/channels/whatsapp_web.rs:1117` | Remove `;` after `if-else` block |
| `cast_sign_loss` | `src/channels/whatsapp_web.rs:1564` | `.timestamp() as u64` → `.timestamp().cast_unsigned()` (MSRV 1.87) |
| `cast_possible_truncation` | `src/channels/whatsapp_web.rs:2077` | `(i + 1) as u32` → `u32::try_from(i + 1).expect(...)` in test |
| `range_plus_one` ×3 | `src/agent/loop_.rs:9011, 9038, 9068` | `0..(N + 1)` → `0..=N` in `trim_history_*` tests |
| `struct_excessive_bools` | `src/config/schema.rs:1315` | `#[allow(...)]` with rationale — `AgentConfig` bools are orthogonal user-facing config switches, not a state machine |

## Validation Evidence (required)

```bash
cargo clippy --profile=test --lib --features whatsapp-web -- -D warnings
# Clean. (Was 8 errors on main under -D warnings.)

cargo fmt --all -- --check
# 0 diffs.

cargo test --lib --features whatsapp-web trim_history
# 13 passed (inclusive-range rewrites preserve exact loop semantics).

cargo test --lib --features whatsapp-web history_trims
# 2 passed (agent::tests::history_trims_after_max_messages,
#           agent::tests::history_trims_strictly_in_legacy_mode).

cargo test --lib --features whatsapp-web compute_retry_delay
# 3 passed (the `(i + 1) as u32` → `u32::try_from` rewrite preserves
# the same attempt values 1..=10).
```

- Evidence provided: commands + result counts above; lib clippy clean; all touched tests pass.
- If any command is intentionally skipped, explain why: `cargo clippy --all-targets -- -D warnings` fails on main with 4 compile errors in `tests/*.rs` that predate this PR (E0063 `TokenUsage::cache_creation_input_tokens` / `cache_read_input_tokens` missing, E0061 `TelegramChannel::new` arity drift). They are API catch-ups, not lint findings, and belong in a dedicated follow-up.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: The `-100999` → `-100_999` change is a literal-value underscore separator on a Telegram test-fixture chat ID; no real chat/user data introduced.
- Neutral wording confirmation: Pass.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? `No` — code-only change.

## Human Verification (required)

- Verified scenarios:
  - `cargo clippy --profile=test --lib --features whatsapp-web -- -D warnings` is clean.
  - `cargo fmt --all -- --check` reports 0 diffs.
  - `trim_history_*` tests (13 variants) still green after converting `0..(N + 1)` to `0..=N`.
  - `compute_retry_delay_doubles_with_cap` still exercises attempt values 1 through 10 after the `u32::try_from` rewrite.
- Edge cases checked:
  - `.cast_unsigned()` is the stable `i64` → `u64` method added in Rust 1.87 (crate MSRV is 1.87).
  - `Box::pin` wrapping `send_message` changes allocation but not the future's observable behaviour.
  - The seven-trait explicit import list for `wa_rs_core::store::traits` matches the wildcard coverage (verified by successful compile of `RusqliteStore`).
- What was not verified:
  - Full integration test run (`tests/*.rs`) — blocked by pre-existing compile errors unrelated to this PR.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `agent` (trim_history tests only), `channel: telegram` (test fixture literal), `channel: whatsapp` (storage + web runtime paths), `config` (attribute on `AgentConfig`).
- Potential unintended effects:
  - `Box::pin` on `send_message` introduces a heap allocation on the message-send path. Size savings on the enclosing future (~34KB) are meaningful under tight stack budgets; the heap allocation cost is negligible relative to a WhatsApp network round-trip.
  - `.cast_unsigned()` is value-preserving when the i64 is non-negative (always true for `Utc::now().timestamp()` post-1970).
- Guardrails/monitoring for early detection: CI test run on this PR; any regression in `whatsapp_web` send or storage would surface in daemon logs on the remote instance.

## Agent Collaboration Notes (recommended)

- Agent tools used: `cargo clippy`, `cargo fmt`, `cargo test`.
- Workflow/plan summary: Part of the two-step cleanup following #42. #43 handled mechanical fmt; this PR handles per-warning clippy with judgment calls.
- Verification focus: clippy delta (8 → 0 on lib + in-source tests) and that touched tests still pass.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md`): Yes.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge-sha>` — each fix is isolated to its file, revert is surgical.
- Feature flags or config toggles: None.
- Observable failure symptoms: Would appear as compile/test failure in CI; no runtime symptoms expected. The `Box::pin` on `send_message` is the highest-risk behavioural touch — if WhatsApp send breaks post-merge, check the daemon logs for `WhatsApp Web: sent text to` and revert that one hunk.

## Risks and Mitigations

- Risk: `Box::pin(client.send_message(...))` changes the future's storage and could interact badly with `async_trait` or other wrapping layers.
  - Mitigation: clippy's `large_futures` suggestion is for exactly this case; the underlying future is identical, only the storage location changes. Lib builds and clippy passes.
- Risk: The explicit seven-trait import list for `wa_rs_core::store::traits` drifts from the upstream crate if new traits are added.
  - Mitigation: Any new trait required by `RusqliteStore::impl` blocks would cause a compile error at the next sync, which is a clearer signal than a silent glob pulling in extra names.
- Risk: `#[allow(clippy::struct_excessive_bools)]` on `AgentConfig` turns off the lint long-term.
  - Mitigation: A rationale comment documents why: the bools are independent user-facing config switches. If the config shape ever legitimately becomes a state machine, the `#[allow]` can be removed and the refactor done in the same PR.