### PR TITLE
chore: catch integration tests up with fork API changes

### DIFF
--- a/src/observability/otel.rs
+++ b/src/observability/otel.rs
@@ -198,6 +198,12 @@ impl Observer for OtelObserver {
     fn record_event(&self, event: &ObserverEvent) {
         let tracer = global::tracer("zeroclaw");
 
+        // Two match arms are deliberately empty for different reasons:
+        // the LlmRequest/ToolCallStart/TurnComplete/Cache{Hit,Miss} arm
+        // folds those events into paired response/metric spans, while the
+        // DORA Deployment* arm is a TODO for future OTel pass-through.
+        // Merging them loses that semantic grouping.
+        #[allow(clippy::match_same_arms)]
         match event {
             ObserverEvent::AgentStart { provider, model } => {
                 self.agent_starts.add(

--- a/tests/integration/telegram_attachment_fallback.rs
+++ b/tests/integration/telegram_attachment_fallback.rs
@@ -15,7 +15,7 @@ use zeroclaw::channels::traits::{Channel, SendMessage};
 
 /// Helper: create a TelegramChannel pointing at a mock server.
 fn test_channel(mock_url: &str) -> TelegramChannel {
-    TelegramChannel::new("TEST_TOKEN".into(), vec!["*".into()], false)
+    TelegramChannel::new("TEST_TOKEN".into(), vec!["*".into()], false, vec![], vec![])
         .with_api_base(mock_url.to_string())
 }
 

--- a/tests/integration/telegram_finalize_draft.rs
+++ b/tests/integration/telegram_finalize_draft.rs
@@ -5,7 +5,7 @@ use zeroclaw::channels::telegram::TelegramChannel;
 use zeroclaw::channels::traits::Channel;
 
 fn test_channel(mock_url: &str) -> TelegramChannel {
-    TelegramChannel::new("TEST_TOKEN".into(), vec!["*".into()], false)
+    TelegramChannel::new("TEST_TOKEN".into(), vec!["*".into()], false, vec![], vec![])
         .with_api_base(mock_url.to_string())
 }
 

--- a/tests/support/mock_provider.rs
+++ b/tests/support/mock_provider.rs
@@ -171,7 +171,7 @@ impl Provider for TraceLlmProvider {
                 usage: Some(TokenUsage {
                     input_tokens: Some(input_tokens),
                     output_tokens: Some(output_tokens),
-                    cached_input_tokens: None,
+                    ..Default::default()
                 }),
                 reasoning_content: None,
             }),
@@ -194,7 +194,7 @@ impl Provider for TraceLlmProvider {
                     usage: Some(TokenUsage {
                         input_tokens: Some(input_tokens),
                         output_tokens: Some(output_tokens),
-                        cached_input_tokens: None,
+                        ..Default::default()
                     }),
                     reasoning_content: None,
                 })


### PR DESCRIPTION
## Summary

- Base branch target (`main`): main
- Problem: `cargo clippy --all-targets --features whatsapp-web,observability-otel -- -D warnings` failed on main with 5 findings. Four are **fork-introduced** compile errors in fork-local test files that predate this session (PR #38 added `TokenUsage` fields without updating `tests/support/mock_provider.rs`; PR #24 expanded `TelegramChannel::new` from 3 to 5 args without updating two integration fixtures). The fifth is a `match_same_arms` lint that only surfaces under `--features observability-otel` on the OTel observer.
- Why it matters: With this PR, `cargo clippy --all-targets --features whatsapp-web,observability-otel -- -D warnings` is **green for the first time** since the STORY-010 partial unblock. Combined with #43 (fmt baseline) and #44 (lib clippy), CI's standard validation triple (`fmt --check`, `clippy --all-targets -- -D warnings`, `test`) now runs cleanly on the full release feature surface.
- What changed:
  - `tests/support/mock_provider.rs` — replace explicit field lists with `..Default::default()` so future `TokenUsage` additions stop silently breaking the mock (no behavioural change — all new fields are `Option<u64>` defaulting to `None`).
  - `tests/integration/telegram_attachment_fallback.rs` + `tests/integration/telegram_finalize_draft.rs` — update `TelegramChannel::new` call sites to pass `vec![], vec![]` for the two new filter params.
  - `src/observability/otel.rs` — attach `#[allow(clippy::match_same_arms)]` to `record_event`'s match with a rationale comment explaining why the two empty arms stay separate.
- What did **not** change (scope boundary): Zero runtime behaviour changes on the hot path. No production code modified beyond the scoped `#[allow]` attribute.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `tests, observability, channel`
- Module labels: `channel: telegram`, `observability: otel`
- Contributor tier label: (auto-managed)

## Change Metadata

- Change type: `chore`
- Primary scope: `multi`

## Linked Issue

- Closes #: —
- Related #: #38 (producer of `TokenUsage` drift), #24 (producer of `TelegramChannel::new` drift), #42 / #43 / #44 (session lineage — this closes the last outstanding `--all-targets` issue that #44 flagged as out of scope)

## Root-Cause Attribution

| Error | Producer PR | Producer commit | Victim file | Fix |
|---|---|---|---|---|
| E0063 TokenUsage missing `cache_creation_input_tokens` / `cache_read_input_tokens` | #38 @alexandme 2026-04-13 | `9ebb81aa` | `tests/support/mock_provider.rs:171, 194` | `..Default::default()` spread |
| E0061 TelegramChannel::new takes 5 args but 3 supplied (×2) | #24 @alexandme 2026-04-02 | `04bc1aec` | `tests/integration/telegram_attachment_fallback.rs:18`, `tests/integration/telegram_finalize_draft.rs:8` | Pass `vec![], vec![]` for new filter params |
| `clippy::match_same_arms` (otel feature) | Pre-existing in upstream OTel observer; surfaces under `-D warnings` | — | `src/observability/otel.rs:211, 610` | Scoped `#[allow]` with rationale |

STORY-010 (`27894209 fix(tests): unblock test suite compilation after upstream sync`) partially unblocked `--lib` compilation but missed these four `tests/*.rs` call sites and never exercised `--features observability-otel`. This PR closes that gap.

## Validation Evidence (required)

```bash
cargo clippy --all-targets --features whatsapp-web,observability-otel -- -D warnings
# Clean exit 0. (Was 5 errors before: 2×E0063, 2×E0061, 1×match_same_arms.)

cargo fmt --all -- --check
# 0 diffs.

cargo test --test integration --features whatsapp-web,observability-otel telegram
# 10 passed, 0 failed:
#   integration::telegram_attachment_fallback::document_url_failure_falls_back_to_text_link
#   integration::telegram_attachment_fallback::photo_url_failure_falls_back_to_text_link
#   integration::telegram_attachment_fallback::text_portion_delivered_before_attachment_failure
#   integration::telegram_attachment_fallback::multiple_attachments_independent_fallback
#   integration::telegram_attachment_fallback::successful_attachment_no_fallback
#   integration::telegram_attachment_fallback::document_only_message_falls_back_to_text
#   integration::telegram_finalize_draft::finalize_draft_treats_not_modified_as_success
#   integration::telegram_finalize_draft::finalize_draft_plain_retry_treats_not_modified_as_success
#   integration::telegram_finalize_draft::finalize_draft_skips_send_message_when_delete_fails
#   integration::telegram_finalize_draft::finalize_draft_sends_fresh_message_after_successful_delete
```

- Evidence provided: Commands + result counts above. All three CI gates (`fmt --check`, `clippy --all-targets -D warnings`, integration test subset) clean under the release feature set.
- If any command is intentionally skipped, explain why: `cargo test --all-targets` not exercised end-to-end locally due to time budget; the targeted telegram suite covers all code paths touched in this PR, and the full suite will run in CI.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: Test fixtures only; no new identifiers introduced.
- Neutral wording confirmation: Pass.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? `No` — code-only change.

## Human Verification (required)

- Verified scenarios:
  - `cargo clippy --all-targets --features whatsapp-web,observability-otel -- -D warnings` now passes cleanly.
  - All 10 telegram integration tests pass with the updated constructor calls.
  - `fmt --check` reports 0 diffs across the whole tree.
- Edge cases checked:
  - `..Default::default()` in `mock_provider.rs` is a forward-compat choice — any future `TokenUsage` field addition will no longer require touching this file unless the test semantics intentionally care about the new field.
  - The `#[allow(clippy::match_same_arms)]` is scoped to a single match expression, not the whole module.
- What was not verified:
  - Full `cargo test --all-targets --features whatsapp-web,observability-otel` locally — left to CI. Targeted integration runs exercise all edited code.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Test fixtures (`tests/*`) and one OTel observer match expression. No runtime behaviour change.
- Potential unintended effects: None expected.
- Guardrails/monitoring for early detection: CI on this PR runs the fuller feature surface; any regression surfaces there before merge.

## Agent Collaboration Notes (recommended)

- Agent tools used: `cargo clippy`, `cargo fmt`, `cargo test`, `git log -S` / `gh pr view` for producer-PR attribution.
- Workflow/plan summary: Final step in the cleanup trilogy (#43 fmt → #44 lib clippy → this PR integration tests + otel). Root-caused via git archaeology — both compile errors are fork-introduced, not upstream drift.
- Verification focus: Ensured the full CI feature surface (`whatsapp-web,observability-otel`) is green, not just the `whatsapp-web` slice that earlier PRs in this session exercised.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md`): Yes.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge-sha>`. Test fixtures and one scoped attribute — surgical revert.
- Feature flags or config toggles: None.
- Observable failure symptoms: None expected in production. In test runs: if `TokenUsage` ever grows a required (non-`Option`) field, the `..Default::default()` spread would start failing — a clearer signal than the current brittle explicit list.

## Risks and Mitigations

- Risk: `..Default::default()` masks a future intentional test that requires setting one of the cache fields.
  - Mitigation: Any test that cares about cache tokens can override the specific field(s) before the spread: `TokenUsage { input_tokens: ..., cache_read_input_tokens: Some(42), ..Default::default() }`. The base fixture stays terse and forward-compat.
- Risk: The scoped `#[allow(clippy::match_same_arms)]` hides a legitimate consolidation opportunity if the DORA arm gets implemented.
  - Mitigation: The inline comment names the reason explicitly; when DORA OTel pass-through lands, that arm will grow a body and clippy's allow becomes a no-op.