### PR TITLE
feat(agent): STORY-011 — move per-call content out of system message for implicit-caching cache hits

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -4069,12 +4069,8 @@ pub async fn run(
             .map(|r| build_hardware_context(r, &effective_msg, &board_names, rag_limit))
             .unwrap_or_default();
         let context = format!("{mem_context}{hw_context}");
-        let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S %Z");
-        let enriched = if context.is_empty() {
-            format!("[{now}] {effective_msg}")
-        } else {
-            format!("{context}[{now}] {effective_msg}")
-        };
+        let now = super::user_message::format_now();
+        let enriched = super::user_message::enrich_user_message(&now, &effective_msg, &context);
 
         let mut history = vec![
             build_system_message(

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -4070,7 +4070,8 @@ pub async fn run(
             .unwrap_or_default();
         let context = format!("{mem_context}{hw_context}");
         let now = super::user_message::format_now();
-        let enriched = super::user_message::enrich_user_message(&now, &effective_msg, &context);
+        let enriched =
+            super::user_message::enrich_user_message(&now, &model_name, &effective_msg, &context);
 
         let mut history = vec![
             build_system_message(

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -2517,6 +2517,17 @@ pub(crate) async fn run_tool_call_loop(
                 (provider, provider_name, model)
             };
 
+        // STORY-011 Increment 7: inject a fresh `[{now}]` user-role
+        // preamble before every LLM-call boundary inside the tool loop
+        // so the model retains an up-to-date time signal across long
+        // multi-iteration turns. This covers both native-tool and
+        // prompt-mode branches uniformly and is benign for providers
+        // (pure text message).
+        {
+            let now = super::user_message::format_now();
+            history.push(ChatMessage::user(format!("[{now}]")));
+        }
+
         let prepared_messages =
             multimodal::prepare_messages_for_provider(history, multimodal_config).await?;
 
@@ -5459,9 +5470,12 @@ mod tests {
         }
     }
 
+    type CapturedHistories = Arc<Mutex<Vec<Vec<(String, String)>>>>;
+
     struct ScriptedProvider {
         responses: Arc<Mutex<VecDeque<ChatResponse>>>,
         capabilities: ProviderCapabilities,
+        captured_histories: CapturedHistories,
     }
 
     impl ScriptedProvider {
@@ -5478,7 +5492,12 @@ mod tests {
             Self {
                 responses: Arc::new(Mutex::new(scripted)),
                 capabilities: ProviderCapabilities::default(),
+                captured_histories: Arc::new(Mutex::new(Vec::new())),
             }
+        }
+
+        fn captured_histories(&self) -> CapturedHistories {
+            Arc::clone(&self.captured_histories)
         }
 
         fn with_native_tool_support(mut self) -> Self {
@@ -5505,10 +5524,21 @@ mod tests {
 
         async fn chat(
             &self,
-            _request: ChatRequest<'_>,
+            request: ChatRequest<'_>,
             _model: &str,
             _temperature: f64,
         ) -> anyhow::Result<ChatResponse> {
+            {
+                let snapshot: Vec<(String, String)> = request
+                    .messages
+                    .iter()
+                    .map(|m| (m.role.clone(), m.content.clone()))
+                    .collect();
+                self.captured_histories
+                    .lock()
+                    .expect("captured_histories lock should be valid")
+                    .push(snapshot);
+            }
             let mut responses = self
                 .responses
                 .lock()
@@ -6734,6 +6764,96 @@ mod tests {
         assert_eq!(recorded[0]["delivery"], serde_json::json!({"mode": "none"}));
     }
 
+    // STORY-011 Increment 7: Within a multi-iteration tool loop, the model
+    // must see a fresh `[{now}]` preamble on every LLM call so the time
+    // signal never goes stale when a single user turn spans 5+ tool
+    // iterations. The preamble is injected uniformly across the native-tool
+    // and prompt-mode branches before each `provider.chat(...)` call.
+    #[tokio::test]
+    async fn run_tool_call_loop_injects_time_preamble_every_iteration() {
+        // 5 tool_call iterations + 1 final text → 6 total LLM calls.
+        // Vary tool args each turn so the loop-detector circuit breaker
+        // (identical-args repetition) doesn't trip.
+        let provider = ScriptedProvider::from_text_responses(vec![
+            r#"<tool_call>
+{"name":"count_tool","arguments":{"value":"A"}}
+</tool_call>"#,
+            r#"<tool_call>
+{"name":"count_tool","arguments":{"value":"B"}}
+</tool_call>"#,
+            r#"<tool_call>
+{"name":"count_tool","arguments":{"value":"C"}}
+</tool_call>"#,
+            r#"<tool_call>
+{"name":"count_tool","arguments":{"value":"D"}}
+</tool_call>"#,
+            r#"<tool_call>
+{"name":"count_tool","arguments":{"value":"E"}}
+</tool_call>"#,
+            "done",
+        ]);
+        let captured = provider.captured_histories();
+
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let tools_registry: Vec<Box<dyn Tool>> = vec![Box::new(CountingTool::new(
+            "count_tool",
+            Arc::clone(&invocations),
+        ))];
+
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("run tool calls"),
+        ];
+        let observer = NoopObserver;
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            0.0,
+            true,
+            None,
+            "cli",
+            None,
+            &crate::config::MultimodalConfig::default(),
+            10,
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            &crate::config::PacingConfig::default(),
+            0,
+            0,
+            None,
+        )
+        .await
+        .expect("tool loop should finish on final text response");
+        assert_eq!(result, "done");
+
+        let captures = captured.lock().expect("captured lock valid");
+        assert_eq!(
+            captures.len(),
+            6,
+            "expected 6 LLM calls (5 tool iterations + 1 final); got {}",
+            captures.len()
+        );
+        for (idx, snapshot) in captures.iter().enumerate() {
+            let has_timestamp_preamble = snapshot
+                .iter()
+                .any(|(role, content)| role == "user" && content.starts_with("[2"));
+            assert!(
+                has_timestamp_preamble,
+                "iteration {idx}: history must contain a user-role [timestamp] preamble; got: {snapshot:#?}",
+            );
+        }
+    }
+
     #[tokio::test]
     async fn run_tool_call_loop_deduplicates_repeated_tool_calls() {
         let provider = ScriptedProvider::from_text_responses(vec![
@@ -7110,6 +7230,7 @@ mod tests {
                 native_tool_calling: true,
                 ..ProviderCapabilities::default()
             },
+            captured_histories: Arc::new(Mutex::new(Vec::new())),
         };
 
         let invocations = Arc::new(AtomicUsize::new(0));
@@ -9672,6 +9793,7 @@ Let me check the result."#;
                 reasoning_content: None,
             }]))),
             capabilities: ProviderCapabilities::default(),
+            captured_histories: Arc::new(Mutex::new(Vec::new())),
         };
         let observer = NoopObserver;
         let workspace = tempfile::TempDir::new().unwrap();
@@ -9833,6 +9955,7 @@ Let me check the result."#;
                 reasoning_content: None,
             }]))),
             capabilities: ProviderCapabilities::default(),
+            captured_histories: Arc::new(Mutex::new(Vec::new())),
         };
         let observer = NoopObserver;
         let mut history = vec![ChatMessage::system("test"), ChatMessage::user("hello")];

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -15,6 +15,7 @@ pub mod personality;
 pub mod prompt;
 pub mod thinking;
 pub mod tool_execution;
+pub mod user_message;
 
 #[cfg(test)]
 mod tests;

--- a/src/agent/prompt.rs
+++ b/src/agent/prompt.rs
@@ -247,13 +247,16 @@ impl PromptSection for RuntimeSection {
         "runtime"
     }
 
-    fn build(&self, ctx: &PromptContext<'_>) -> Result<String> {
+    fn build(&self, _ctx: &PromptContext<'_>) -> Result<String> {
+        // STORY-011 Increment 6: Host + OS are daemon-restart-stable and
+        // live in the stable prefix. Model was dropped because it mutates
+        // mid-session via `/model` — it now ships in the user-message
+        // preamble (see `agent::user_message::enrich_user_message`).
         let host =
             hostname::get().map_or_else(|_| "unknown".into(), |h| h.to_string_lossy().to_string());
         Ok(format!(
-            "## Runtime\n\nHost: {host} | OS: {} | Model: {}",
+            "## Host Environment\n\nHost: {host} | OS: {}",
             std::env::consts::OS,
-            ctx.model_name
         ))
     }
 }
@@ -402,6 +405,36 @@ mod tests {
         assert!(
             !prompt.contains("## Current Date & Time"),
             "SystemPromptBuilder::with_defaults() must not emit a date/time section; got:\n{prompt}"
+        );
+    }
+
+    // STORY-011 Increment 6: the Agent-path SystemPromptBuilder must not emit
+    // the `Model:` name (it mutates mid-session via `/model`). The model name
+    // ships in the user-message preamble instead so the stable prefix stays
+    // byte-identical across `/model` switches.
+    #[test]
+    fn story_011_default_prompt_builder_omits_model_name() {
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(TestTool)];
+        let ctx = PromptContext {
+            workspace_dir: Path::new("/tmp"),
+            model_name: "qwen/qwen3.6-plus",
+            tools: &tools,
+            skills: &[],
+            skills_prompt_mode: crate::config::SkillsPromptInjectionMode::Full,
+            identity_config: None,
+            dispatcher_instructions: "",
+            tool_descriptions: None,
+            security_summary: None,
+            autonomy_level: AutonomyLevel::Supervised,
+        };
+        let prompt = SystemPromptBuilder::with_defaults().build(&ctx).unwrap();
+        assert!(
+            !prompt.contains("Model:"),
+            "SystemPromptBuilder::with_defaults() must not emit `Model:`; got:\n{prompt}"
+        );
+        assert!(
+            !prompt.contains("qwen/qwen3.6-plus"),
+            "SystemPromptBuilder::with_defaults() must not emit the model name; got:\n{prompt}"
         );
     }
 

--- a/src/agent/prompt.rs
+++ b/src/agent/prompt.rs
@@ -6,7 +6,6 @@ use crate::security::AutonomyLevel;
 use crate::skills::Skill;
 use crate::tools::Tool;
 use anyhow::Result;
-use chrono::{Datelike, Local, Timelike};
 use std::fmt::Write;
 use std::path::Path;
 
@@ -44,9 +43,12 @@ pub struct SystemPromptBuilder {
 
 impl SystemPromptBuilder {
     pub fn with_defaults() -> Self {
+        // STORY-011 Increment 3: `DateTimeSection` removed from defaults.
+        // The per-call date/time signal now lives only in the user-facing
+        // message preamble (Phase B), so implicit-caching providers see a
+        // byte-identical system prefix across calls.
         Self {
             sections: vec![
-                Box::new(DateTimeSection),
                 Box::new(IdentitySection),
                 Box::new(ToolHonestySection),
                 Box::new(ToolsSection),
@@ -85,7 +87,6 @@ pub struct SafetySection;
 pub struct SkillsSection;
 pub struct WorkspaceSection;
 pub struct RuntimeSection;
-pub struct DateTimeSection;
 pub struct ChannelMediaSection;
 
 impl PromptSection for IdentitySection {
@@ -257,30 +258,6 @@ impl PromptSection for RuntimeSection {
     }
 }
 
-impl PromptSection for DateTimeSection {
-    fn name(&self) -> &str {
-        "datetime"
-    }
-
-    fn build(&self, _ctx: &PromptContext<'_>) -> Result<String> {
-        let now = Local::now();
-        // Force Gregorian year to avoid confusion with local calendars (e.g. Buddhist calendar).
-        let (year, month, day) = (now.year(), now.month(), now.day());
-        let (hour, minute, second) = (now.hour(), now.minute(), now.second());
-        let tz = now.format("%Z");
-
-        Ok(format!(
-            "## CRITICAL CONTEXT: CURRENT DATE & TIME\n\n\
-             The following is the ABSOLUTE TRUTH regarding the current date and time. \
-             Use this for all relative time calculations (e.g. \"last 7 days\").\n\n\
-             Date: {year:04}-{month:02}-{day:02}\n\
-             Time: {hour:02}:{minute:02}:{second:02} ({tz})\n\
-             ISO 8601: {year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}{}",
-            now.format("%:z")
-        ))
-    }
-}
-
 impl PromptSection for ChannelMediaSection {
     fn name(&self) -> &str {
         "channel_media"
@@ -397,6 +374,37 @@ mod tests {
         assert!(prompt.contains("instr"));
     }
 
+    // STORY-011 Increment 3: the Agent-path SystemPromptBuilder must not emit
+    // a per-call date/time section via DateTimeSection. This is the third
+    // system-message emission site (after build_dynamic_system_block and
+    // build_system_prompt_parts_with_mode_and_autonomy in channels/mod.rs).
+    // Implicit-caching providers need a byte-identical prefix across calls.
+    #[test]
+    fn story_011_default_prompt_builder_omits_date_time_section() {
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(TestTool)];
+        let ctx = PromptContext {
+            workspace_dir: Path::new("/tmp"),
+            model_name: "qwen/qwen3.6-plus",
+            tools: &tools,
+            skills: &[],
+            skills_prompt_mode: crate::config::SkillsPromptInjectionMode::Full,
+            identity_config: None,
+            dispatcher_instructions: "",
+            tool_descriptions: None,
+            security_summary: None,
+            autonomy_level: AutonomyLevel::Supervised,
+        };
+        let prompt = SystemPromptBuilder::with_defaults().build(&ctx).unwrap();
+        assert!(
+            !prompt.contains("CURRENT DATE & TIME"),
+            "SystemPromptBuilder::with_defaults() must not emit a date/time section; got:\n{prompt}"
+        );
+        assert!(
+            !prompt.contains("## Current Date & Time"),
+            "SystemPromptBuilder::with_defaults() must not emit a date/time section; got:\n{prompt}"
+        );
+    }
+
     #[test]
     fn skills_section_includes_instructions_and_tools() {
         let tools: Vec<Box<dyn Tool>> = vec![];
@@ -482,31 +490,6 @@ mod tests {
         // Registered tools (shell kind) appear under <callable_tools> with prefixed names.
         assert!(output.contains("<callable_tools"));
         assert!(output.contains("<name>deploy.release_checklist</name>"));
-    }
-
-    #[test]
-    fn datetime_section_includes_timestamp_and_timezone() {
-        let tools: Vec<Box<dyn Tool>> = vec![];
-        let ctx = PromptContext {
-            workspace_dir: Path::new("/tmp"),
-            model_name: "test-model",
-            tools: &tools,
-            skills: &[],
-            skills_prompt_mode: crate::config::SkillsPromptInjectionMode::Full,
-            identity_config: None,
-            dispatcher_instructions: "instr",
-            tool_descriptions: None,
-            security_summary: None,
-            autonomy_level: AutonomyLevel::Supervised,
-        };
-
-        let rendered = DateTimeSection.build(&ctx).unwrap();
-        assert!(rendered.starts_with("## CRITICAL CONTEXT: CURRENT DATE & TIME\n\n"));
-
-        let payload = rendered.trim_start_matches("## CRITICAL CONTEXT: CURRENT DATE & TIME\n\n");
-        assert!(payload.chars().any(|c| c.is_ascii_digit()));
-        assert!(payload.contains("Date:"));
-        assert!(payload.contains("Time:"));
     }
 
     #[test]

--- a/src/agent/user_message.rs
+++ b/src/agent/user_message.rs
@@ -1,0 +1,50 @@
+use chrono::Local;
+
+/// Format a wall-clock timestamp in the canonical user-preamble form.
+pub fn format_now() -> String {
+    Local::now().format("%Y-%m-%d %H:%M:%S %Z").to_string()
+}
+
+/// Build the enriched user-message content sent to the LLM.
+///
+/// The per-turn timestamp prefix (`[{now}]`) lives here — outside the
+/// system message — so that implicit-caching providers (Qwen, DeepSeek,
+/// Groq, OpenAI, Moonshot) keep a byte-identical system prefix across
+/// turns and actually reuse the prompt cache.
+///
+/// `mem_context` is any pre-computed memory/RAG context that the caller
+/// wants to prepend (used by the CLI/REST `agent::run` path). The
+/// channel daemon path leaves it empty because memory context lives in
+/// the system dynamic block there.
+pub fn enrich_user_message(now: &str, raw: &str, mem_context: &str) -> String {
+    if mem_context.is_empty() {
+        format!("[{now}] {raw}")
+    } else {
+        format!("{mem_context}[{now}] {raw}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enrich_without_context() {
+        let out = enrich_user_message("2026-04-17 10:00:00 CEST", "hello", "");
+        assert_eq!(out, "[2026-04-17 10:00:00 CEST] hello");
+    }
+
+    #[test]
+    fn enrich_with_context() {
+        let out = enrich_user_message("2026-04-17 10:00:00 CEST", "hello", "## Memory\nfoo\n\n");
+        assert_eq!(out, "## Memory\nfoo\n\n[2026-04-17 10:00:00 CEST] hello");
+    }
+
+    #[test]
+    fn format_now_matches_shape() {
+        let s = format_now();
+        // Shape: `YYYY-MM-DD HH:MM:SS <tz>`
+        assert!(s.starts_with('2'), "year should start with 2, got: {s}");
+        assert!(s.len() >= 19, "timestamp too short: {s:?}");
+    }
+}

--- a/src/agent/user_message.rs
+++ b/src/agent/user_message.rs
@@ -7,20 +7,22 @@ pub fn format_now() -> String {
 
 /// Build the enriched user-message content sent to the LLM.
 ///
-/// The per-turn timestamp prefix (`[{now}]`) lives here — outside the
-/// system message — so that implicit-caching providers (Qwen, DeepSeek,
-/// Groq, OpenAI, Moonshot) keep a byte-identical system prefix across
-/// turns and actually reuse the prompt cache.
+/// The per-turn timestamp prefix and the active model name live here —
+/// outside the system message — so that implicit-caching providers
+/// (Qwen, DeepSeek, Groq, OpenAI, Moonshot) keep a byte-identical system
+/// prefix across turns and actually reuse the prompt cache.
+///
+/// Format: `[{now} | model={model}] {mem_context?}{raw}`.
 ///
 /// `mem_context` is any pre-computed memory/RAG context that the caller
 /// wants to prepend (used by the CLI/REST `agent::run` path). The
 /// channel daemon path leaves it empty because memory context lives in
 /// the system dynamic block there.
-pub fn enrich_user_message(now: &str, raw: &str, mem_context: &str) -> String {
+pub fn enrich_user_message(now: &str, model: &str, raw: &str, mem_context: &str) -> String {
     if mem_context.is_empty() {
-        format!("[{now}] {raw}")
+        format!("[{now} | model={model}] {raw}")
     } else {
-        format!("{mem_context}[{now}] {raw}")
+        format!("{mem_context}[{now} | model={model}] {raw}")
     }
 }
 
@@ -30,14 +32,22 @@ mod tests {
 
     #[test]
     fn enrich_without_context() {
-        let out = enrich_user_message("2026-04-17 10:00:00 CEST", "hello", "");
-        assert_eq!(out, "[2026-04-17 10:00:00 CEST] hello");
+        let out = enrich_user_message("2026-04-17 10:00:00 CEST", "m1", "hello", "");
+        assert_eq!(out, "[2026-04-17 10:00:00 CEST | model=m1] hello");
     }
 
     #[test]
     fn enrich_with_context() {
-        let out = enrich_user_message("2026-04-17 10:00:00 CEST", "hello", "## Memory\nfoo\n\n");
-        assert_eq!(out, "## Memory\nfoo\n\n[2026-04-17 10:00:00 CEST] hello");
+        let out = enrich_user_message(
+            "2026-04-17 10:00:00 CEST",
+            "m1",
+            "hello",
+            "## Memory\nfoo\n\n",
+        );
+        assert_eq!(
+            out,
+            "## Memory\nfoo\n\n[2026-04-17 10:00:00 CEST | model=m1] hello"
+        );
     }
 
     #[test]

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -9473,9 +9473,20 @@ BTC is currently around $65,000 based on latest tool output."#
         let ws = make_workspace();
         let prompt = build_system_prompt(ws.path(), "claude-sonnet-4", &[], &[], None, None);
 
-        assert!(prompt.contains("Model: claude-sonnet-4"));
+        // STORY-011: Host + OS live in the stable `## Host Environment`
+        // section. Model is intentionally absent from the system prompt —
+        // it mutates mid-session via `/model` and is now emitted in the
+        // user-message preamble instead (Phase B).
+        assert!(
+            prompt.contains("## Host Environment"),
+            "missing `## Host Environment` section; got:\n{prompt}"
+        );
         assert!(prompt.contains(&format!("OS: {}", std::env::consts::OS)));
         assert!(prompt.contains("Host:"));
+        assert!(
+            !prompt.contains("Model: claude-sonnet-4"),
+            "STORY-011: Model must not appear in the system prompt; got:\n{prompt}"
+        );
     }
 
     #[test]

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -9159,7 +9159,12 @@ BTC is currently around $65,000 based on latest tool output."#
         let tools = vec![("shell", "Run commands"), ("file_read", "Read files")];
         let prompt = build_system_prompt(ws.path(), "test-model", &tools, &[], None, None);
 
-        // Section headers
+        // Section headers — the stable prefix carries identity, tools, safety,
+        // skills, workspace, project context, channel capabilities, and host
+        // environment. STORY-011 removed `## Current Date & Time` and
+        // `## Runtime` from the system message; both now live in the
+        // user-message preamble instead (Phase B wires `## Host Environment`
+        // + the user-facing `Model:` label; first-turn `[{now}]` prefix stays).
         assert!(prompt.contains("## Tools"), "missing Tools section");
         assert!(prompt.contains("## Safety"), "missing Safety section");
         assert!(prompt.contains("## Workspace"), "missing Workspace section");
@@ -9168,10 +9173,17 @@ BTC is currently around $65,000 based on latest tool output."#
             "missing Project Context"
         );
         assert!(
-            prompt.contains("## Current Date & Time"),
-            "missing Date/Time"
+            !prompt.contains("## Current Date & Time"),
+            "STORY-011: Date/Time must not appear in the system prompt; got:\n{prompt}"
         );
-        assert!(prompt.contains("## Runtime"), "missing Runtime section");
+        assert!(
+            !prompt.contains("## Runtime"),
+            "STORY-011: `## Runtime` must not appear in the system prompt (Host/OS moved to `## Host Environment`, Model moves to user preamble in Phase B); got:\n{prompt}"
+        );
+        assert!(
+            prompt.contains("## Host Environment"),
+            "missing `## Host Environment` section (replacement for stable Host/OS fields); got:\n{prompt}"
+        );
     }
 
     // STORY-011 Increment 1: the per-turn dynamic block must not carry a

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -2777,12 +2777,27 @@ async fn process_channel_message(
             .is_some_and(|turns| !turns.is_empty())
     };
 
+    // Enrich the current user-turn content with a `[{now}]` timestamp
+    // prefix so the per-call timestamp lives in the user message rather
+    // than the system block. Keeping timestamps out of the system block
+    // preserves a byte-identical stable prefix across turns on
+    // implicit-caching providers (Qwen/DeepSeek/Groq/OpenAI/Moonshot).
+    // Memory recall below still queries on raw `msg.content` so the
+    // retrieval vector isn't polluted by the timestamp prefix.
+    let now_for_user_turn = crate::agent::user_message::format_now();
+    let enriched_user_content =
+        crate::agent::user_message::enrich_user_message(&now_for_user_turn, &msg.content, "");
+
     // Preserve user turn before the LLM call so interrupted requests keep context.
-    append_sender_turn(ctx.as_ref(), &history_key, ChatMessage::user(&msg.content));
+    append_sender_turn(
+        ctx.as_ref(),
+        &history_key,
+        ChatMessage::user(&enriched_user_content),
+    );
 
     // Build history from per-sender conversation cache.
     let prior_turns_raw = if force_fresh_session {
-        vec![ChatMessage::user(&msg.content)]
+        vec![ChatMessage::user(&enriched_user_content)]
     } else {
         ctx.conversation_histories
             .lock()
@@ -3654,7 +3669,11 @@ async fn process_channel_message(
                 );
                 let should_rollback_user_turn = should_rollback_failed_user_turn(&e);
                 let rolled_back = should_rollback_user_turn
-                    && rollback_orphan_user_turn(ctx.as_ref(), &history_key, &msg.content);
+                    && rollback_orphan_user_turn(
+                        ctx.as_ref(),
+                        &history_key,
+                        &enriched_user_content,
+                    );
 
                 if !rolled_back {
                     // Close the orphan user turn so subsequent messages don't
@@ -10145,6 +10164,109 @@ BTC is currently around $65,000 based on latest tool output."#
     }
 
     #[tokio::test]
+    async fn process_channel_message_user_turn_carries_timestamp_prefix() {
+        let channel_impl = Arc::new(RecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let mut channels_by_name = HashMap::new();
+        channels_by_name.insert(channel.name().to_string(), channel);
+
+        let provider_impl = Arc::new(HistoryCaptureProvider::default());
+
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            channels_by_name: Arc::new(channels_by_name),
+            provider: provider_impl.clone(),
+            default_provider: Arc::new("test-provider".to_string()),
+            memory: Arc::new(NoopMemory),
+            tools_registry: Arc::new(vec![]),
+            observer: Arc::new(NoopObserver),
+            system_prompt: Arc::new("test-system-prompt".to_string()),
+            stable_system_prefix: Arc::new(String::new()),
+            model: Arc::new("test-model".to_string()),
+            temperature: 0.0,
+            auto_save_memory: false,
+            max_tool_iterations: 5,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(lru::LruCache::new(
+                std::num::NonZeroUsize::new(MAX_CONVERSATION_SENDERS).unwrap(),
+            ))),
+            pending_new_sessions: Arc::new(Mutex::new(HashSet::new())),
+            provider_cache: Arc::new(Mutex::new(HashMap::new())),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            api_key: None,
+            api_url: None,
+            reliability: Arc::new(crate::config::ReliabilityConfig::default()),
+            provider_runtime_options: providers::ProviderRuntimeOptions::default(),
+            workspace_dir: Arc::new(std::env::temp_dir()),
+            prompt_config: Arc::new(crate::config::Config::default()),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            interrupt_on_new_message: InterruptOnNewMessageConfig {
+                telegram: false,
+                slack: false,
+                discord: false,
+                mattermost: false,
+                matrix: false,
+            },
+            multimodal: crate::config::MultimodalConfig::default(),
+            media_pipeline: crate::config::MediaPipelineConfig::default(),
+            transcription_config: crate::config::TranscriptionConfig::default(),
+            hooks: None,
+            non_cli_excluded_tools: Arc::new(Vec::new()),
+            autonomy_level: AutonomyLevel::default(),
+            tool_call_dedup_exempt: Arc::new(Vec::new()),
+            model_routes: Arc::new(Vec::new()),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            ack_reactions: true,
+            show_tool_calls: true,
+            session_store: None,
+            observe_store: None,
+            approval_manager: Arc::new(ApprovalManager::for_non_interactive(
+                &crate::config::AutonomyConfig::default(),
+            )),
+            activated_tools: None,
+            cost_tracking: None,
+            pacing: crate::config::PacingConfig::default(),
+            max_tool_result_chars: 0,
+            context_token_budget: 0,
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
+        });
+
+        process_channel_message(
+            runtime_ctx,
+            traits::ChannelMessage {
+                id: "msg-a".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-1".to_string(),
+                content: "hello there".to_string(),
+                channel: "test-channel".to_string(),
+                timestamp: 1,
+                thread_ts: None,
+                interruption_scope_id: None,
+                attachments: vec![],
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        let calls = provider_impl
+            .calls
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        assert_eq!(calls.len(), 1, "expected exactly one LLM call");
+        // calls[0][1] is the first user turn; must begin with a timestamp
+        // prefix of the form `[YYYY-MM-DD HH:MM:SS ...]`.
+        let user_turn = &calls[0][1].1;
+        assert!(
+            user_turn.starts_with("[2"),
+            "expected channel user turn to start with `[2<year>`, got: {user_turn:?}"
+        );
+        assert!(
+            user_turn.contains("hello there"),
+            "expected original user content preserved, got: {user_turn:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn process_channel_message_refreshes_available_skills_after_new_session() {
         let workspace = make_workspace();
         let mut config = Config::default();
@@ -10449,7 +10571,14 @@ BTC is currently around $65,000 based on latest tool output."#
         assert!(calls[0][0].1.contains("[Memory context]"));
         assert!(calls[0][0].1.contains("Age is 45"));
         assert_eq!(calls[0][1].0, "user");
-        assert_eq!(calls[0][1].1, "hello");
+        // User turn carries `[{now}]` timestamp prefix but NOT memory context.
+        let user_turn = &calls[0][1].1;
+        assert!(
+            user_turn.starts_with("[2"),
+            "expected timestamp prefix, got: {user_turn:?}"
+        );
+        assert!(user_turn.contains("hello"));
+        assert!(!user_turn.contains("[Memory context]"));
 
         let histories = runtime_ctx
             .conversation_histories
@@ -10459,7 +10588,8 @@ BTC is currently around $65,000 based on latest tool output."#
             .peek("test-channel_chat-ctx_alice")
             .expect("history should be stored for sender");
         assert_eq!(turns[0].role, "user");
-        assert_eq!(turns[0].content, "hello");
+        assert!(turns[0].content.starts_with("[2"));
+        assert!(turns[0].content.contains("hello"));
         assert!(!turns[0].content.contains("[Memory context]"));
     }
 
@@ -11283,7 +11413,8 @@ This is an example JSON object for profile settings."#;
             .expect("history should exist for sender");
         assert_eq!(turns.len(), 2);
         assert_eq!(turns[0].role, "user");
-        assert_eq!(turns[0].content, "What is WAL?");
+        assert!(turns[0].content.starts_with("[2"));
+        assert!(turns[0].content.contains("What is WAL?"));
         assert_eq!(turns[1].role, "assistant");
         assert_eq!(turns[1].content, "ok");
         assert!(
@@ -11415,13 +11546,14 @@ This is an example JSON object for profile settings."#;
             .expect("history should exist for sender");
         assert_eq!(turns.len(), 2);
         assert_eq!(turns[0].role, "user");
-        assert_eq!(turns[0].content, "What is WAL?");
+        assert!(turns[0].content.starts_with("[2"));
+        assert!(turns[0].content.contains("What is WAL?"));
         assert_eq!(turns[1].role, "assistant");
         assert_eq!(turns[1].content, "ok");
         assert!(
             turns
                 .iter()
-                .all(|turn| turn.content != "trigger format error"),
+                .all(|turn| !turn.content.contains("trigger format error")),
             "failed non-retryable turn must not persist in history"
         );
     }

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -10154,15 +10154,22 @@ BTC is currently around $65,000 based on latest tool output."#
             .calls
             .lock()
             .unwrap_or_else(|e| e.into_inner());
+        // STORY-011 Increment 7: `run_tool_call_loop` injects a
+        // `[{now}]` user-role preamble before each LLM call, so each
+        // captured history has one extra trailing user turn.
         assert_eq!(calls.len(), 2);
-        assert_eq!(calls[0].len(), 2);
+        assert_eq!(calls[0].len(), 3);
         assert_eq!(calls[0][0].0, "system");
         assert_eq!(calls[0][1].0, "user");
-        assert_eq!(calls[1].len(), 4);
+        assert_eq!(calls[0][2].0, "user");
+        assert!(calls[0][2].1.starts_with("[2"));
+        assert_eq!(calls[1].len(), 5);
         assert_eq!(calls[1][0].0, "system");
         assert_eq!(calls[1][1].0, "user");
         assert_eq!(calls[1][2].0, "assistant");
         assert_eq!(calls[1][3].0, "user");
+        assert_eq!(calls[1][4].0, "user");
+        assert!(calls[1][4].1.starts_with("[2"));
         assert!(calls[1][1].1.contains("hello"));
         assert!(calls[1][2].1.contains("response-1"));
         assert!(calls[1][3].1.contains("follow up"));
@@ -10670,7 +10677,9 @@ BTC is currently around $65,000 based on latest tool output."#
             .lock()
             .unwrap_or_else(|e| e.into_inner());
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].len(), 2);
+        // STORY-011 Increment 7: +1 trailing user-role `[{now}]` preamble
+        // injected before every LLM call inside the tool loop.
+        assert_eq!(calls[0].len(), 3);
         // Memory context is injected into the system prompt, not the user message.
         assert_eq!(calls[0][0].0, "system");
         assert!(calls[0][0].1.contains("[Memory context]"));
@@ -10684,6 +10693,8 @@ BTC is currently around $65,000 based on latest tool output."#
         );
         assert!(user_turn.contains("hello"));
         assert!(!user_turn.contains("[Memory context]"));
+        assert_eq!(calls[0][2].0, "user");
+        assert!(calls[0][2].1.starts_with("[2"));
 
         let histories = runtime_ctx
             .conversation_histories
@@ -10796,13 +10807,16 @@ BTC is currently around $65,000 based on latest tool output."#
             .lock()
             .unwrap_or_else(|e| e.into_inner());
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].len(), 4);
+        // STORY-011 Increment 7: +1 trailing user-role `[{now}]` preamble
+        // injected by `run_tool_call_loop` before each LLM call.
+        assert_eq!(calls[0].len(), 5);
 
         let roles = calls[0]
             .iter()
             .map(|(role, _)| role.as_str())
             .collect::<Vec<_>>();
-        assert_eq!(roles, vec!["system", "user", "assistant", "user"]);
+        assert_eq!(roles, vec!["system", "user", "assistant", "user", "user"]);
+        assert!(calls[0][4].1.starts_with("[2"));
         assert!(
             calls[0][0].1.contains("When responding on Telegram:"),
             "telegram channel instructions should be embedded into the system prompt"

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -680,22 +680,23 @@ fn channel_delivery_instructions(channel_name: &str) -> Option<&'static str> {
     }
 }
 
-/// Build the per-turn dynamic system block: currently just `## Runtime`.
+/// Build the per-turn dynamic system block.
 ///
-/// STORY-011 Increment 1 removed the `## Current Date & Time` header from
-/// this block. Implicit-caching providers (Qwen, DeepSeek, Groq, OpenAI,
-/// Moonshot) cache the longest byte-identical prefix across requests, so
-/// the timestamp cannot live anywhere inside the system message without
-/// invalidating the cache on every call. The `[{now}]` prefix on the
-/// user-facing message is now the canonical current-time signal; see
-/// Phase B of STORY-011 for the user-message wiring.
-fn build_dynamic_system_block(model: &str) -> String {
-    let host =
-        hostname::get().map_or_else(|_| "unknown".into(), |h| h.to_string_lossy().to_string());
-    format!(
-        "## Runtime\n\nHost: {host} | OS: {} | Model: {model}\n",
-        std::env::consts::OS,
-    )
+/// STORY-011 Increments 1 & 4: this block carries no per-call content
+/// anymore. `## Current Date & Time` moved to the user-message preamble
+/// (Phase B); `## Runtime` split — Host+OS to the stable prefix,
+/// `Model:` to the user preamble. Implicit-caching providers need a
+/// byte-identical prefix across requests, so any timestamp or mutable
+/// runtime value inside the system message invalidates the cache on
+/// every call.
+///
+/// The function returns an empty string today. It's kept (rather than
+/// inlined) so that Phase B and future stories have a well-known hook
+/// for injecting new per-turn content if needed, without having to
+/// restructure the `build_channel_system_prompt` / `process_channel_message`
+/// call sites that feed it into `ChatMessage::system_with_stable_prefix`.
+fn build_dynamic_system_block(_model: &str) -> String {
+    String::new()
 }
 
 /// Append channel-specific instructions and a per-conversation
@@ -4245,9 +4246,12 @@ pub fn build_system_prompt_parts_with_mode_and_autonomy(
     }
 
     // ── Truncation (max_system_prompt_chars budget) ────────────
-    // Applied to the stable block only. The dynamic suffix is tiny (<1KB)
-    // and must not be truncated because it carries Date & Time / Runtime
-    // context the model relies on for "today" questions.
+    // Applied to the stable block's bootstrap content. STORY-011 post-fix:
+    // the dynamic suffix is now empty (all per-call content moved to the
+    // user-message preamble), and the sections appended below — Channel
+    // Capabilities (config-driven, daemon-stable) and Host Environment
+    // (env-constant) — are also stable and added AFTER this truncation so
+    // they survive even when the bootstrap is clipped.
     if max_system_prompt_chars > 0 && stable.len() > max_system_prompt_chars {
         // Truncate on a char boundary, keeping the top portion (identity + safety).
         let mut end = max_system_prompt_chars;
@@ -4259,19 +4263,17 @@ pub fn build_system_prompt_parts_with_mode_and_autonomy(
         stable.push_str("\n\n[System prompt truncated to fit context budget]\n");
     }
 
-    // ── Dynamic suffix ─────────────────────────────────────────
-    // Channel Capabilities, Date & Time, and Runtime change (or could
-    // change) per call and must live *after* the cache breakpoint so the
-    // stable prefix hash survives across invocations.
-    let mut dynamic = String::with_capacity(1024);
-
-    // ── 8. Channel Capabilities (skipped in compact_context mode) ──
+    // ── 8. Channel Capabilities (STORY-011 AC #8: moved from dynamic → stable)
+    // Content branches on `autonomy_config.level` and `compact_context`, both
+    // of which are daemon-restart-stable. Placing this block in the stable
+    // prefix (and after truncation) keeps it in every request while letting
+    // implicit-caching providers see a byte-identical prefix across calls.
     if !compact_context {
-        dynamic.push_str("## Channel Capabilities\n\n");
-        dynamic.push_str("- You are running as a messaging bot. Your response is automatically sent back to the user's channel.\n");
-        dynamic
+        stable.push_str("## Channel Capabilities\n\n");
+        stable.push_str("- You are running as a messaging bot. Your response is automatically sent back to the user's channel.\n");
+        stable
             .push_str("- You do NOT need to ask permission to respond — just respond directly.\n");
-        dynamic.push_str(match autonomy_config.map(|cfg| cfg.level) {
+        stable.push_str(match autonomy_config.map(|cfg| cfg.level) {
         Some(crate::security::AutonomyLevel::Full) => {
             "- If the runtime policy already allows a tool, use it directly; do not ask the user for extra approval.\n\
              - Never pretend you are waiting for a human approval click or confirmation when the runtime policy already permits the action.\n\
@@ -4285,26 +4287,31 @@ pub fn build_system_prompt_parts_with_mode_and_autonomy(
              - If there is no approval path for this channel or the runtime blocks an action, explain that restriction directly instead of simulating an approval flow.\n"
         }
     });
-        dynamic.push_str("- NEVER repeat, describe, or echo credentials, tokens, API keys, or secrets in your responses.\n");
-        dynamic.push_str("- If a tool output contains credentials, they have already been redacted — do not mention them.\n");
-        dynamic.push_str("- When a user sends a voice note, it is automatically transcribed to text. Your text reply is automatically converted to a voice note and sent back. Do NOT attempt to generate audio yourself — TTS is handled by the channel.\n");
-        dynamic.push_str("- NEVER narrate or describe your tool usage. Do NOT say 'Let me fetch...', 'I will use...', 'Searching...', or similar. Give the FINAL ANSWER only — no intermediate steps, no tool mentions, no progress updates.\n\n");
+        stable.push_str("- NEVER repeat, describe, or echo credentials, tokens, API keys, or secrets in your responses.\n");
+        stable.push_str("- If a tool output contains credentials, they have already been redacted — do not mention them.\n");
+        stable.push_str("- When a user sends a voice note, it is automatically transcribed to text. Your text reply is automatically converted to a voice note and sent back. Do NOT attempt to generate audio yourself — TTS is handled by the channel.\n");
+        stable.push_str("- NEVER narrate or describe your tool usage. Do NOT say 'Let me fetch...', 'I will use...', 'Searching...', or similar. Give the FINAL ANSWER only — no intermediate steps, no tool mentions, no progress updates.\n\n");
     }
 
-    // ── 6. Runtime ──────────────────────────────────────────────
-    // STORY-011 Increment 2: the `## Current Date & Time` header was removed
-    // from this dynamic block. Implicit-caching providers invalidate the
-    // entire prefix on any per-call tail content, and the user-message
-    // `[{now}]` prefix is now the canonical current-time signal. Runtime is
-    // kept here for Increment 4 to split further (Host/OS → stable; Model →
-    // user preamble in Phase B).
+    // ── 9. Host Environment (STORY-011 AC #8: split from Runtime) ──
+    // Host + OS are env-constant (daemon-restart-stable). Model is mutable
+    // mid-session via `/model` and therefore NOT included here — Phase B
+    // injects it via the user-message preamble so cache bytes don't shift
+    // when the active model changes.
     let host =
         hostname::get().map_or_else(|_| "unknown".into(), |h| h.to_string_lossy().to_string());
     let _ = writeln!(
-        dynamic,
-        "## Runtime\n\nHost: {host} | OS: {} | Model: {model_name}\n",
+        stable,
+        "## Host Environment\n\nHost: {host} | OS: {}\n",
         std::env::consts::OS,
     );
+
+    // ── Dynamic suffix ─────────────────────────────────────────
+    // STORY-011: empty by design. Per-call content (timestamp, model name)
+    // lives in the user-message preamble so the stable prefix stays
+    // byte-identical across turns for implicit-caching providers.
+    let _ = model_name; // unused now that Model: moves to user preamble
+    let dynamic = String::new();
 
     if stable.is_empty() && dynamic.is_empty() {
         return SystemPromptParts {
@@ -9211,6 +9218,115 @@ BTC is currently around $65,000 based on latest tool output."#
             !parts.dynamic.contains("## Current Date & Time"),
             "parts.dynamic must not contain per-call `## Current Date & Time`; got:\n{}",
             parts.dynamic
+        );
+    }
+
+    // STORY-011 Increment 4: split `## Runtime` and move `## Channel
+    // Capabilities`. AC #8 option (b): Host+OS go to the stable prefix,
+    // Model is dropped from the system message entirely (Phase B injects
+    // it via the user-message preamble). `## Channel Capabilities` is
+    // config-driven (autonomy level is daemon-restart-stable) so it moves
+    // from parts.dynamic to parts.stable.
+    #[test]
+    fn story_011_stable_has_host_os_not_model_and_byte_identical_across_models() {
+        let ws = make_workspace();
+        let parts_qwen = build_system_prompt_parts_with_mode_and_autonomy(
+            ws.path(),
+            "qwen/qwen3.6-plus",
+            &[],
+            &[],
+            None,
+            None,
+            None,
+            false,
+            crate::config::SkillsPromptInjectionMode::Full,
+            false,
+            0,
+        );
+        let parts_claude = build_system_prompt_parts_with_mode_and_autonomy(
+            ws.path(),
+            "anthropic/claude-sonnet-4.6",
+            &[],
+            &[],
+            None,
+            None,
+            None,
+            false,
+            crate::config::SkillsPromptInjectionMode::Full,
+            false,
+            0,
+        );
+
+        // (a) stable has Host + OS, no Model
+        assert!(
+            parts_qwen.stable.contains("Host:"),
+            "stable must contain Host:; got:\n{}",
+            parts_qwen.stable
+        );
+        assert!(
+            parts_qwen.stable.contains("OS:"),
+            "stable must contain OS:; got:\n{}",
+            parts_qwen.stable
+        );
+        assert!(
+            !parts_qwen.stable.contains("Model:"),
+            "stable must NOT contain Model: — it mutates via /model mid-session; got:\n{}",
+            parts_qwen.stable
+        );
+
+        // (b) stable is byte-identical across different model_name arguments
+        assert_eq!(
+            parts_qwen.stable, parts_claude.stable,
+            "stable prefix must survive /model mid-session; differing bytes would invalidate the cache"
+        );
+
+        // (d) Channel Capabilities in stable, not dynamic
+        assert!(
+            parts_qwen.stable.contains("## Channel Capabilities"),
+            "stable must contain `## Channel Capabilities`; got:\n{}",
+            parts_qwen.stable
+        );
+        assert!(
+            !parts_qwen.dynamic.contains("## Channel Capabilities"),
+            "dynamic must NOT contain `## Channel Capabilities`; got:\n{}",
+            parts_qwen.dynamic
+        );
+
+        // SystemPromptParts dynamic must not carry Runtime or the Host/OS/Model
+        // fields either — they're now in stable (Host+OS) or user preamble (Model).
+        assert!(
+            !parts_qwen.dynamic.contains("## Runtime"),
+            "dynamic must NOT contain `## Runtime`; got:\n{}",
+            parts_qwen.dynamic
+        );
+        assert!(
+            !parts_qwen.dynamic.contains("Model:"),
+            "dynamic must NOT contain `Model:`; got:\n{}",
+            parts_qwen.dynamic
+        );
+    }
+
+    // STORY-011 Increment 4: the channel-runtime path `build_dynamic_system_block`
+    // must no longer emit `## Runtime` or any Host/OS/Model fields. Those live
+    // in the stable prefix (Host/OS) or the user preamble (Model).
+    #[test]
+    fn story_011_dynamic_system_block_omits_runtime_and_host_os_model() {
+        let out = build_dynamic_system_block("qwen/qwen3.6-plus");
+        assert!(
+            !out.contains("## Runtime"),
+            "build_dynamic_system_block must not emit `## Runtime`; got:\n{out}"
+        );
+        assert!(
+            !out.contains("Host:"),
+            "build_dynamic_system_block must not emit `Host:`; got:\n{out}"
+        );
+        assert!(
+            !out.contains("OS:"),
+            "build_dynamic_system_block must not emit `OS:`; got:\n{out}"
+        );
+        assert!(
+            !out.contains("Model:"),
+            "build_dynamic_system_block must not emit `Model:`; got:\n{out}"
         );
     }
 

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -4291,16 +4291,13 @@ pub fn build_system_prompt_parts_with_mode_and_autonomy(
         dynamic.push_str("- NEVER narrate or describe your tool usage. Do NOT say 'Let me fetch...', 'I will use...', 'Searching...', or similar. Give the FINAL ANSWER only — no intermediate steps, no tool mentions, no progress updates.\n\n");
     }
 
-    // ── 6. Date & Time ──────────────────────────────────────────
-    let now = chrono::Local::now();
-    let _ = writeln!(
-        dynamic,
-        "## Current Date & Time\n\n{} ({})\n",
-        now.format("%Y-%m-%d %H:%M:%S"),
-        now.format("%Z")
-    );
-
-    // ── 7. Runtime ──────────────────────────────────────────────
+    // ── 6. Runtime ──────────────────────────────────────────────
+    // STORY-011 Increment 2: the `## Current Date & Time` header was removed
+    // from this dynamic block. Implicit-caching providers invalidate the
+    // entire prefix on any per-call tail content, and the user-message
+    // `[{now}]` prefix is now the canonical current-time signal. Runtime is
+    // kept here for Increment 4 to split further (Host/OS → stable; Model →
+    // user preamble in Phase B).
     let host =
         hostname::get().map_or_else(|_| "unknown".into(), |h| h.to_string_lossy().to_string());
     let _ = writeln!(
@@ -9181,6 +9178,39 @@ BTC is currently around $65,000 based on latest tool output."#
         assert!(
             !out.contains("## Current Date & Time"),
             "build_dynamic_system_block must not emit a per-call `## Current Date & Time` header; got:\n{out}"
+        );
+    }
+
+    // STORY-011 Increment 2: the agent/CLI-path SystemPromptParts builder
+    // (called at daemon startup to seed `ctx.stable_system_prefix`) must not
+    // emit `## Current Date & Time` into either half of the parts. This is a
+    // separate emission site from `build_dynamic_system_block` and covers
+    // the `run_tool_call_loop` path via `SystemPromptParts`.
+    #[test]
+    fn story_011_system_prompt_parts_omits_current_date_time() {
+        let ws = make_workspace();
+        let parts = build_system_prompt_parts_with_mode_and_autonomy(
+            ws.path(),
+            "qwen/qwen3.6-plus",
+            &[],
+            &[],
+            None,
+            None,
+            None,
+            false,
+            crate::config::SkillsPromptInjectionMode::Full,
+            false,
+            0,
+        );
+        assert!(
+            !parts.stable.contains("## Current Date & Time"),
+            "parts.stable must not contain per-call `## Current Date & Time`; got:\n{}",
+            parts.stable
+        );
+        assert!(
+            !parts.dynamic.contains("## Current Date & Time"),
+            "parts.dynamic must not contain per-call `## Current Date & Time`; got:\n{}",
+            parts.dynamic
         );
     }
 

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -680,20 +680,20 @@ fn channel_delivery_instructions(channel_name: &str) -> Option<&'static str> {
     }
 }
 
-/// Build the per-turn dynamic system block: `## Current Date & Time`
-/// followed by `## Runtime`. This is the byte-volatile portion of the
-/// system prompt that lives **after** the Anthropic cache breakpoint, so
-/// the stable prefix (identity, tools, safety, skills, bootstrap) can be
-/// served from the prefix cache while the timestamps and runtime info
-/// are re-sent on every call.
+/// Build the per-turn dynamic system block: currently just `## Runtime`.
+///
+/// STORY-011 Increment 1 removed the `## Current Date & Time` header from
+/// this block. Implicit-caching providers (Qwen, DeepSeek, Groq, OpenAI,
+/// Moonshot) cache the longest byte-identical prefix across requests, so
+/// the timestamp cannot live anywhere inside the system message without
+/// invalidating the cache on every call. The `[{now}]` prefix on the
+/// user-facing message is now the canonical current-time signal; see
+/// Phase B of STORY-011 for the user-message wiring.
 fn build_dynamic_system_block(model: &str) -> String {
-    let now = chrono::Local::now();
     let host =
         hostname::get().map_or_else(|_| "unknown".into(), |h| h.to_string_lossy().to_string());
     format!(
-        "## Current Date & Time\n\n{} ({})\n\n## Runtime\n\nHost: {host} | OS: {} | Model: {model}\n",
-        now.format("%Y-%m-%d %H:%M:%S"),
-        now.format("%Z"),
+        "## Runtime\n\nHost: {host} | OS: {} | Model: {model}\n",
         std::env::consts::OS,
     )
 }
@@ -9168,6 +9168,20 @@ BTC is currently around $65,000 based on latest tool output."#
             "missing Date/Time"
         );
         assert!(prompt.contains("## Runtime"), "missing Runtime section");
+    }
+
+    // STORY-011 Increment 1: the per-turn dynamic block must not carry a
+    // `## Current Date & Time` header. Implicit-caching providers (Qwen,
+    // DeepSeek, Groq, OpenAI, Moonshot) match on the longest byte-identical
+    // prefix across calls; a timestamp inside the system message invalidates
+    // the entire prefix on every request.
+    #[test]
+    fn story_011_dynamic_system_block_omits_current_date_time() {
+        let out = build_dynamic_system_block("qwen/qwen3.6-plus");
+        assert!(
+            !out.contains("## Current Date & Time"),
+            "build_dynamic_system_block must not emit a per-call `## Current Date & Time` header; got:\n{out}"
+        );
     }
 
     #[test]

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -2777,16 +2777,21 @@ async fn process_channel_message(
             .is_some_and(|turns| !turns.is_empty())
     };
 
-    // Enrich the current user-turn content with a `[{now}]` timestamp
-    // prefix so the per-call timestamp lives in the user message rather
-    // than the system block. Keeping timestamps out of the system block
-    // preserves a byte-identical stable prefix across turns on
-    // implicit-caching providers (Qwen/DeepSeek/Groq/OpenAI/Moonshot).
-    // Memory recall below still queries on raw `msg.content` so the
-    // retrieval vector isn't polluted by the timestamp prefix.
+    // Enrich the current user-turn content with a `[{now} | model={m}]`
+    // preamble so both the per-turn timestamp and the active model name
+    // live in the user message rather than the system block. Keeping
+    // these out of the system block preserves a byte-identical stable
+    // prefix across turns on implicit-caching providers
+    // (Qwen/DeepSeek/Groq/OpenAI/Moonshot). Memory recall below still
+    // queries on raw `msg.content` so the retrieval vector isn't polluted
+    // by the preamble.
     let now_for_user_turn = crate::agent::user_message::format_now();
-    let enriched_user_content =
-        crate::agent::user_message::enrich_user_message(&now_for_user_turn, &msg.content, "");
+    let enriched_user_content = crate::agent::user_message::enrich_user_message(
+        &now_for_user_turn,
+        route.model.as_str(),
+        &msg.content,
+        "",
+    );
 
     // Preserve user turn before the LLM call so interrupted requests keep context.
     append_sender_turn(
@@ -10161,6 +10166,106 @@ BTC is currently around $65,000 based on latest tool output."#
         assert!(calls[1][1].1.contains("hello"));
         assert!(calls[1][2].1.contains("response-1"));
         assert!(calls[1][3].1.contains("follow up"));
+    }
+
+    #[tokio::test]
+    async fn process_channel_message_user_turn_carries_model_name() {
+        // STORY-011 Increment 6: the user-message preamble carries the
+        // active model name so the model sees its own identity on every
+        // turn without the name appearing in the stable system prefix.
+        let channel_impl = Arc::new(RecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let mut channels_by_name = HashMap::new();
+        channels_by_name.insert(channel.name().to_string(), channel);
+
+        let provider_impl = Arc::new(HistoryCaptureProvider::default());
+
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            channels_by_name: Arc::new(channels_by_name),
+            provider: provider_impl.clone(),
+            default_provider: Arc::new("test-provider".to_string()),
+            memory: Arc::new(NoopMemory),
+            tools_registry: Arc::new(vec![]),
+            observer: Arc::new(NoopObserver),
+            system_prompt: Arc::new("test-system-prompt".to_string()),
+            stable_system_prefix: Arc::new(String::new()),
+            model: Arc::new("test-model".to_string()),
+            temperature: 0.0,
+            auto_save_memory: false,
+            max_tool_iterations: 5,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(lru::LruCache::new(
+                std::num::NonZeroUsize::new(MAX_CONVERSATION_SENDERS).unwrap(),
+            ))),
+            pending_new_sessions: Arc::new(Mutex::new(HashSet::new())),
+            provider_cache: Arc::new(Mutex::new(HashMap::new())),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            api_key: None,
+            api_url: None,
+            reliability: Arc::new(crate::config::ReliabilityConfig::default()),
+            provider_runtime_options: providers::ProviderRuntimeOptions::default(),
+            workspace_dir: Arc::new(std::env::temp_dir()),
+            prompt_config: Arc::new(crate::config::Config::default()),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            interrupt_on_new_message: InterruptOnNewMessageConfig {
+                telegram: false,
+                slack: false,
+                discord: false,
+                mattermost: false,
+                matrix: false,
+            },
+            multimodal: crate::config::MultimodalConfig::default(),
+            media_pipeline: crate::config::MediaPipelineConfig::default(),
+            transcription_config: crate::config::TranscriptionConfig::default(),
+            hooks: None,
+            non_cli_excluded_tools: Arc::new(Vec::new()),
+            autonomy_level: AutonomyLevel::default(),
+            tool_call_dedup_exempt: Arc::new(Vec::new()),
+            model_routes: Arc::new(Vec::new()),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            ack_reactions: true,
+            show_tool_calls: true,
+            session_store: None,
+            observe_store: None,
+            approval_manager: Arc::new(ApprovalManager::for_non_interactive(
+                &crate::config::AutonomyConfig::default(),
+            )),
+            activated_tools: None,
+            cost_tracking: None,
+            pacing: crate::config::PacingConfig::default(),
+            max_tool_result_chars: 0,
+            context_token_budget: 0,
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
+        });
+
+        process_channel_message(
+            runtime_ctx,
+            traits::ChannelMessage {
+                id: "msg-m".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-1".to_string(),
+                content: "hello".to_string(),
+                channel: "test-channel".to_string(),
+                timestamp: 1,
+                thread_ts: None,
+                interruption_scope_id: None,
+                attachments: vec![],
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        let calls = provider_impl
+            .calls
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        assert_eq!(calls.len(), 1);
+        let user_turn = &calls[0][1].1;
+        assert!(
+            user_turn.contains("model=test-model"),
+            "expected `model=test-model` in user preamble, got: {user_turn:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/providers/openrouter.rs
+++ b/src/providers/openrouter.rs
@@ -1537,6 +1537,55 @@ mod tests {
     }
 
     // ═══════════════════════════════════════════════════════════════════════
+    // STORY-011 Phase C regression guards
+    // ═══════════════════════════════════════════════════════════════════════
+
+    #[test]
+    fn story_011_system_message_has_no_timestamp_no_model_and_one_cache_control() {
+        // STORY-011 invariant: the serialized OpenRouter system message must
+        // carry neither the old `## Current Date & Time` section nor the
+        // `Model:` label (both now live in the user-message preamble) AND
+        // must expose exactly ONE `ephemeral` cache_control breakpoint on
+        // the stable block. Implicit-caching providers (Qwen, DeepSeek,
+        // Groq, OpenAI, Moonshot) ignore cache_control and key on the
+        // longest byte-identical prefix; a timestamp or per-model label in
+        // the system message would drop cache hits to 0% on every turn.
+        let stable = "## Identity\n\nYou are ZeroClaw.\n\n\
+                      ## Tools\n\n- shell: Run commands\n\n\
+                      ## Safety\n\n- NEVER repeat credentials.\n\n\
+                      ## Channel Capabilities\n\nrunning as a messaging bot\n\n\
+                      ## Host Environment\n\nHost: testhost | OS: macos\n";
+        let dynamic = "";
+
+        let msg = ChatMessage::system_with_stable_prefix(stable, dynamic);
+        let api = OpenRouterProvider::to_history_message(&msg);
+        let json = serde_json::to_value(&api.content).unwrap();
+        let json_str = serde_json::to_string(&json).unwrap();
+
+        assert!(
+            !json_str.contains("## Current Date & Time"),
+            "STORY-011: serialized system message must not contain `## Current Date & Time`; got: {json_str}"
+        );
+        assert!(
+            !json_str.contains("Model:"),
+            "STORY-011: serialized system message must not contain `Model:` label (moved to user preamble); got: {json_str}"
+        );
+
+        let parts = json.as_array().expect("system content must be Parts");
+        let ephemeral_count = parts
+            .iter()
+            .filter(|p| {
+                p.get("cache_control").and_then(|c| c.get("type"))
+                    == Some(&serde_json::json!("ephemeral"))
+            })
+            .count();
+        assert_eq!(
+            ephemeral_count, 1,
+            "STORY-011: exactly one MessagePart must carry cache_control.type=ephemeral; got parts: {parts:?}"
+        );
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
     // prompt caching: response-side token mapping (Unit 3)
     // ═══════════════════════════════════════════════════════════════════════
 

--- a/src/providers/openrouter.rs
+++ b/src/providers/openrouter.rs
@@ -1585,6 +1585,43 @@ mod tests {
         );
     }
 
+    #[test]
+    fn story_011_single_ephemeral_breakpoint_covers_stable_block() {
+        // Regression guard — verifies the cache breakpoint covers the stable
+        // content, not the dynamic. Anthropic/Claude respect cache_control
+        // explicitly; Qwen & other implicit-caching providers ignore it, but
+        // if a future change migrated the breakpoint to the dynamic block,
+        // Anthropic would cache mutating content and miss on every turn.
+        let stable = "## Identity\n\nYou are ZeroClaw.\n\n\
+                      ## Host Environment\n\nHost: testhost | OS: macos\n";
+        let dynamic = "hello";
+
+        let msg = ChatMessage::system_with_stable_prefix(stable, dynamic);
+        let api = OpenRouterProvider::to_history_message(&msg);
+        let json = serde_json::to_value(&api.content).unwrap();
+        let parts = json.as_array().expect("system content must be Parts");
+
+        let cached: Vec<_> = parts
+            .iter()
+            .filter(|p| {
+                p.get("cache_control").and_then(|c| c.get("type"))
+                    == Some(&serde_json::json!("ephemeral"))
+            })
+            .collect();
+        assert_eq!(
+            cached.len(),
+            1,
+            "expected exactly one ephemeral breakpoint, got {cached:?}"
+        );
+        let cached_text = cached[0]["text"]
+            .as_str()
+            .expect("cached part must have text");
+        assert!(
+            cached_text.contains("## Host Environment"),
+            "the single ephemeral breakpoint must cover the stable block (which contains `## Host Environment`); got cached text: {cached_text}"
+        );
+    }
+
     // ═══════════════════════════════════════════════════════════════════════
     // prompt caching: response-side token mapping (Unit 3)
     // ═══════════════════════════════════════════════════════════════════════

--- a/src/tools/delegate.rs
+++ b/src/tools/delegate.rs
@@ -1056,12 +1056,14 @@ impl DelegateTool {
             autonomy_level: crate::security::AutonomyLevel::default(),
         };
 
+        // STORY-011 Increment 3: `DateTimeSection` was removed. The delegate
+        // agent inherits the parent's entry-path timestamp injection and no
+        // longer needs a per-call system-prompt date section.
         let builder = SystemPromptBuilder::default()
             .add_section(Box::new(crate::agent::prompt::ToolsSection))
             .add_section(Box::new(crate::agent::prompt::SafetySection))
             .add_section(Box::new(crate::agent::prompt::SkillsSection))
-            .add_section(Box::new(crate::agent::prompt::WorkspaceSection))
-            .add_section(Box::new(crate::agent::prompt::DateTimeSection));
+            .add_section(Box::new(crate::agent::prompt::WorkspaceSection));
 
         let mut enriched = builder.build(&ctx).unwrap_or_default();
 

--- a/src/tools/delegate.rs
+++ b/src/tools/delegate.rs
@@ -2050,9 +2050,15 @@ mod tests {
             prompt.contains(&workspace.display().to_string()),
             "should contain workspace path"
         );
+        // STORY-011: the delegate-agent prompt no longer emits a
+        // `## CRITICAL CONTEXT: CURRENT DATE & TIME` section. Per-call
+        // date/time must not live inside the system message or
+        // implicit-caching providers (Qwen, DeepSeek, Groq, OpenAI,
+        // Moonshot) invalidate the prefix on every request. Delegate
+        // agents inherit the parent's entry-path user-message timestamp.
         assert!(
-            prompt.contains("## CRITICAL CONTEXT: CURRENT DATE & TIME"),
-            "should contain datetime section"
+            !prompt.contains("## CRITICAL CONTEXT: CURRENT DATE & TIME"),
+            "STORY-011: delegate prompt must not emit DateTimeSection; got:\n{prompt}"
         );
         assert!(
             prompt.contains("You are a code reviewer."),


### PR DESCRIPTION
Resolves #47.

## Summary
Qwen 3.6 Plus and other implicit-caching providers (DeepSeek, Groq, OpenAI, Moonshot) ignore `cache_control` breakpoints and cache only the longest byte-identical prefix. Moving per-call content (timestamps, model name) out of the system message and into the user-message preamble makes the stable prefix byte-stable across turns, unlocking ~99% cache hit rate (post-cold-start) that was previously 0% on Qwen. Anthropic/Claude, which respect `cache_control` explicitly, continue to work via a single ephemeral breakpoint on the stable block.

## Phase A — System-message cleanup + Runtime split
- `82024c8f` refactor(channels): remove Current Date & Time from build_dynamic_system_block (STORY-011 #1)
- `9c2b1b04` refactor(channels): remove Current Date & Time from SystemPromptParts builder (STORY-011 #2)
- `8df55a51` refactor(prompt): remove dead DateTimeSection emission (STORY-011 #3)
- `6ad7c5ea` refactor(channels): split Runtime (Host/OS→stable, drop Model) + Channel Caps→stable (STORY-011 #4)
- `bde1e440`, `6f9ed784` — test fixups for legacy prompt-section assertions

## Phase B — User-message timestamp + tool-loop preamble
- `0d3250f2` feat(agent): channel path user message carries `[{now}]` prefix + shared `enrich_user_message` helper (STORY-011 #5)
- `f34023bb` feat(agent): model name moves from system prompt to user preamble (STORY-011 #6)
- `c1479f72` feat(agent): user-role time preamble at each LLM-call boundary in tool loop (STORY-011 #7)

## Phase C — Invariant guards
- `8dc9913c` test(openrouter): assert system message has no timestamp and one cache_control breakpoint (STORY-011 #8)
- `9ba22499` test(openrouter): assert single ephemeral breakpoint on stable block (STORY-011 #10)
- Increment #9 (strengthen channels/mod.rs prompt-section assertions) skipped — positive-side coverage already exists in `src/agent/user_message.rs` tests (`enrich_without_context`, `enrich_with_context`, `format_now_matches_shape`) with exact-string assertions. Duplicating them in channels/mod.rs system-prompt tests would mix test concerns (dropper vs. receiver of the relocated content).

## ACs covered
- AC #1, #2, #3a, #4, #5, #6, #7, #8 — pre-merge, all met.
- AC #3b — live dual-provider verification (Anthropic + Qwen) is post-merge.

## Test results

`cargo test --features whatsapp-web`:
- Lib unit tests: 6032 passed, 12 failed, 3 ignored. The 12 failures are the pre-existing sandbox-only baseline (wiremock port-bind restrictions in sandbox); verified unchanged against `main`.
- Integration tests: 149 passed, 10 failed. The 10 Telegram integration failures also pre-exist on `main`; verified by checking out main and re-running.
- Component / live / system / manual suites: all pass or expectedly ignored.

`cargo clippy --features whatsapp-web --all-targets -- -D warnings`: clean.
`cargo fmt --check`: clean.

## Why this is safe pre-merge
The Phase C test additions are **regression guards** — the invariants they enforce were already held after Phase A + B landed. Running them post-Phase-B passes on first run, confirming no behavior change in this branch; the guards exist to catch future regressions that might silently reintroduce per-call content into the system message (which would drop cache hits to 0% on implicit-caching providers).
